### PR TITLE
Business Link and Directgov logos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'kaminari'
 
 gem 'gds-api-adapters', '~> 0.2.2'
 gem 'plek'
-gem 'slimmer', '1.2.4'
+gem 'slimmer', '2.0.0'
 
 gem 'unicorn', '~> 4.3.1'
 
@@ -30,7 +30,7 @@ end
 
 group :test do
   gem 'brakeman', '~> 1.7.0'
-  gem 'fakeweb'
+  gem 'webmock'
   gem 'factory_girl_rails'
   gem 'forgery'
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,7 @@ GEM
     activesupport (3.2.8)
       i18n (~> 0.6)
       multi_json (~> 1.0)
+    addressable (2.3.2)
     airbrake (3.1.2)
       activesupport
       builder
@@ -65,6 +66,7 @@ GEM
       execjs
     coffee-script-source (1.3.3)
     columnize (0.3.6)
+    crack (0.3.1)
     debugger (1.2.0)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.1.1)
@@ -81,7 +83,6 @@ GEM
     factory_girl_rails (4.0.0)
       factory_girl (~> 4.0.0)
       railties (>= 3.0.0)
-    fakeweb (1.3.0)
     fastercsv (1.5.5)
     forgery (0.5.0)
     gds-api-adapters (0.2.2)
@@ -204,8 +205,7 @@ GEM
     simplecov-html (0.5.3)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (1.2.4)
-      gds-api-adapters (>= 0.0.33, < 0.3.0)
+    slimmer (2.0.0)
       json
       nokogiri (~> 1.5.0)
       null_logger
@@ -233,6 +233,9 @@ GEM
       rack
       raindrops (~> 0.7)
     vcr (2.2.4)
+    webmock (1.8.9)
+      addressable (>= 2.2.7)
+      crack (>= 0.1.7)
 
 PLATFORMS
   ruby
@@ -246,7 +249,6 @@ DEPENDENCIES
   coffee-rails (~> 3.2.1)
   debugger
   factory_girl_rails
-  fakeweb
   forgery
   gds-api-adapters (~> 0.2.2)
   httparty
@@ -265,8 +267,9 @@ DEPENDENCIES
   simple_form
   simplecov
   simplecov-rcov
-  slimmer (= 1.2.4)
+  slimmer (= 2.0.0)
   therubyracer
   uglifier (>= 1.0.3)
   unicorn (~> 4.3.1)
   vcr
+  webmock

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,15 @@
 require 'api_entity'
 require "slimmer/headers"
+require 'gds_api/helpers'
 
 class ApplicationController < ActionController::Base
   protect_from_forgery
   include Slimmer::Headers
+  include GdsApi::Helpers
 
   before_filter :initialize_modules
   before_filter :set_cache
+  before_filter :load_artefact
   after_filter :set_analytics_headers
 
   layout :set_layout
@@ -50,6 +53,11 @@ class ApplicationController < ActionController::Base
 
   def set_cache
     expires_in 2.hours, :public => true, 'max-stale' => 0
+  end
+
+  def load_artefact
+    @artefact = fetch_artefact(slug: APP_SLUG)
+    set_slimmer_artefact(@artefact)
   end
 
   def set_analytics_headers

--- a/app/views/layouts/pages.html.erb
+++ b/app/views/layouts/pages.html.erb
@@ -17,7 +17,7 @@
   <%# The citizen class is going to be deprecated, to be replaced with mainstream. %>
   <%# Added the mainstream class in preparation for the change. %>
   <body class="citizen mainstream">
-    <div id="wrapper" class="service business">
+    <div id="wrapper" class="service">
       <section id="content" role="main" class="group">
         <%= render 'shared/header' %>
         <div class="article-container group">

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe ApplicationController do
+
+  describe "behaviour for all subclasses" do
+    controller do
+      def index
+        render :text => "Jabberwocky"
+      end
+    end
+
+    it "should fetch the artefact and pass it to slimmer" do
+      mock_artefact = {"slug" => APP_SLUG, "title" => "Trade Tariff"}
+      GdsApi::Panopticon.any_instance.should_receive(:artefact_for_slug).with(APP_SLUG).and_return(mock_artefact)
+      @controller.should_receive(:set_slimmer_artefact).with(mock_artefact)
+
+      get :index
+    end
+  end
+end

--- a/spec/support/gds_api.rb
+++ b/spec/support/gds_api.rb
@@ -1,0 +1,8 @@
+require 'gds_api/test_helpers/panopticon'
+
+RSpec.configure do |config|
+  config.include GdsApi::TestHelpers::Panopticon, :type => :controller
+  config.before :each, :type => :controller do
+    stub_panopticon_default_artefact
+  end
+end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,9 +1,9 @@
 require 'vcr'
-require 'fakeweb'
+require 'webmock/rspec'
 
 VCR.configure do |c|
   c.cassette_library_dir = Rails.root.join('spec', 'vcr')
-  c.hook_into :fakeweb
+  c.hook_into :webmock
   c.default_cassette_options = { match_requests_on: [:path] }
   c.configure_rspec_metadata!
 end


### PR DESCRIPTION
Update to slimmer 2.0 to set classes for businesslink and directgov logos.  alphagov/static#20 should be merged first.

This allows slimmer to generate the wrapper classes to control the
display of the BusinessLink and Directgov logos.

Had to switch from fakeweb to webmock to allow usage of the gds_api test
helpers.
