### PR TITLE
Make the formatters take an options hash instead of n arguments

### DIFF
--- a/app/formatters/description_formatter.rb
+++ b/app/formatters/description_formatter.rb
@@ -1,6 +1,6 @@
 class DescriptionFormatter
-  def self.format(element = "")
-    str = element.dup
+  def self.format(opts = {})
+    str = opts[:description]
     str.gsub!("|", "&nbsp;")
     str.gsub!("!1!", "<br />")
     str.gsub!("!X!", "&times;")

--- a/app/formatters/description_trim_formatter.rb
+++ b/app/formatters/description_trim_formatter.rb
@@ -1,6 +1,6 @@
 class DescriptionTrimFormatter
-  def self.format(element = "")
-    str = element.dup
+  def self.format(opts = {})
+    str = opts[:description]
     str.gsub!("|", " ")
     str.gsub!("!1!", "")
     str.gsub!("!X!", "")

--- a/app/formatters/duty_expression_formatter.rb
+++ b/app/formatters/duty_expression_formatter.rb
@@ -1,5 +1,12 @@
 class DutyExpressionFormatter
-  def self.format(duty_expression_id, duty_expression_description, duty_amount, monetary_unit, measurement_unit, measurement_unit_qualifier)
+  def self.format(opts={})
+    duty_expression_id = opts[:duty_expression_id]
+    duty_expression_description = opts[:duty_expression_description]
+    duty_amount = opts[:duty_amount]
+    monetary_unit = opts[:monetary_unit]
+    measurement_unit = opts[:measurement_unit]
+    measurement_unit_qualifier = opts[:measurement_unit_qualifier]
+    
     @formatted = ""
     if duty_amount.present?
       @formatted << sprintf("%.2f", duty_amount)

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -11,12 +11,13 @@ class Chapter
   has_many :headings
 
   format :description, with: DescriptionFormatter,
-                       using: [:description]
+                       using: [:description], 
+                       as: :formatted_decription
 
   alias :code :goods_nomenclature_item_id
 
   def to_s
-    description.mb_chars.downcase.to_s.gsub(/^(.)/) { $1.capitalize }
+    formatted_decription.mb_chars.downcase.to_s.gsub(/^(.)/) { $1.capitalize }
   end
 
   def short_code

--- a/app/models/concerns/formatter.rb
+++ b/app/models/concerns/formatter.rb
@@ -10,15 +10,16 @@ module Models
         resulting_method ||= attribute
 
         define_method(resulting_method) do
-          values = using.inject([]) { |memo, field|
-            memo << (if field.is_a?(String)
-                      field
-                    elsif field.is_a?(Symbol)
-                      attributes[field.to_s]
-                    end)
-          }
-
-          formatter.format(*values)
+          opts = {}
+          using.each do |field|
+            if field.is_a?(String)
+              opts[field.to_sym] = field
+            elsif
+              field.is_a?(Symbol)
+              opts[field] = attributes[field.to_s]
+            end
+          end
+          formatter.format(opts)
         end
       end
     end

--- a/spec/formatters/description_formatter_spec.rb
+++ b/spec/formatters/description_formatter_spec.rb
@@ -4,43 +4,43 @@ require 'description_formatter'
 describe DescriptionFormatter do
   describe '.format' do
     it 'replaces | with non breaking space html entity' do
-      DescriptionFormatter.format(' | ').should == ' &nbsp; '
+      DescriptionFormatter.format(description: ' | ').should == ' &nbsp; '
     end
 
     it 'replaces !1! with breaking space tags' do
-      DescriptionFormatter.format(' !1! ').should == ' <br /> '
+      DescriptionFormatter.format(description: ' !1! ').should == ' <br /> '
     end
 
     it 'replaces !X! with times html entity' do
-      DescriptionFormatter.format(' !X! ').should == ' &times; '
+      DescriptionFormatter.format(description: ' !X! ').should == ' &times; '
     end
 
     it 'replaces !x! with times html entity' do
-      DescriptionFormatter.format(' !x! ').should == ' &times; '
+      DescriptionFormatter.format(description: ' !x! ').should == ' &times; '
     end
 
     it 'replaces !o! with deg html entity' do
-      DescriptionFormatter.format(' !o! ').should == ' &deg; '
+      DescriptionFormatter.format(description: ' !o! ').should == ' &deg; '
     end
 
     it 'replaces !O! with deg html entity' do
-      DescriptionFormatter.format(' !O! ').should == ' &deg; '
+      DescriptionFormatter.format(description: ' !O! ').should == ' &deg; '
     end
 
     it 'replaces !>=! with greater or equals html entity' do
-      DescriptionFormatter.format(' !>=! ').should == ' &ge; '
+      DescriptionFormatter.format(description: ' !>=! ').should == ' &ge; '
     end
 
     it 'replaces !<=! with less or equal html entity' do
-      DescriptionFormatter.format(' !<=! ').should == ' &le; '
+      DescriptionFormatter.format(description: ' !<=! ').should == ' &le; '
     end
 
     it 'replaces and wraps @<anycharacter> with html sub tag' do
-      DescriptionFormatter.format(' @1 ').should == ' <sub>1</sub> '
+      DescriptionFormatter.format(description: ' @1 ').should == ' <sub>1</sub> '
     end
 
     it 'replaces and wraps $<anycharacter> with html sup tag' do
-      DescriptionFormatter.format(' $1 ').should == ' <sup>1</sup> '
+      DescriptionFormatter.format(description: ' $1 ').should == ' <sup>1</sup> '
     end
   end
 end

--- a/spec/formatters/description_trim_formatter_spec.rb
+++ b/spec/formatters/description_trim_formatter_spec.rb
@@ -4,43 +4,43 @@ require 'description_trim_formatter'
 describe DescriptionTrimFormatter do
   describe '.format' do
     it 'replaces | with empty space' do
-      DescriptionTrimFormatter.format('|').should == ' '
+      DescriptionTrimFormatter.format(description: '|').should == ' '
     end
 
     it 'strips !1!' do
-      DescriptionTrimFormatter.format('!1!').should == ''
+      DescriptionTrimFormatter.format(description: '!1!').should == ''
     end
 
     it 'strips !X!' do
-      DescriptionTrimFormatter.format('!X!').should == ''
+      DescriptionTrimFormatter.format(description: '!X!').should == ''
     end
 
     it 'strips !x!' do
-      DescriptionTrimFormatter.format('!x!').should == ''
+      DescriptionTrimFormatter.format(description: '!x!').should == ''
     end
 
     it 'strips !o!' do
-      DescriptionTrimFormatter.format('!o!').should == ''
+      DescriptionTrimFormatter.format(description: '!o!').should == ''
     end
 
     it 'strips !O!' do
-      DescriptionTrimFormatter.format('!O!').should == ''
+      DescriptionTrimFormatter.format(description: '!O!').should == ''
     end
 
     it 'strips !>=!' do
-      DescriptionTrimFormatter.format('!>=!').should == ''
+      DescriptionTrimFormatter.format(description: '!>=!').should == ''
     end
 
     it 'strips !<=!' do
-      DescriptionTrimFormatter.format('!<=!').should == ''
+      DescriptionTrimFormatter.format(description: '!<=!').should == ''
     end
 
     it 'replaces  @<anycharacter> with <anycharacter>' do
-      DescriptionTrimFormatter.format('@1').should == '1'
+      DescriptionTrimFormatter.format(description: '@1').should == '1'
     end
 
     it 'replaces $<anycharacter> with <anycharacter>' do
-      DescriptionTrimFormatter.format('$1').should == '1'
+      DescriptionTrimFormatter.format(description: '$1').should == '1'
     end
   end
 end

--- a/spec/formatters/duty_expression_formatter_spec.rb
+++ b/spec/formatters/duty_expression_formatter_spec.rb
@@ -1,35 +1,56 @@
 require 'spec_helper'
 require 'duty_expression_formatter'
-
+        
 describe DutyExpressionFormatter do
   describe '.format' do
+    let!(:opts){ Hash.new }
     context 'duty amount is preset' do
       it 'gets included into formatted result' do
-        DutyExpressionFormatter.format("01", nil, 30, nil, nil, nil).should == "30.00"
+        opts[:duty_expression_id] = "01"
+        opts[:duty_amount] = 30
+        DutyExpressionFormatter.format(opts).should == "30.00"
       end
     end
 
     context 'duty expression description is present' do
       it 'gets included into formatted result' do
-        DutyExpressionFormatter.format("01", "test", 30, nil, nil, nil).should == "30.00 test"
+        opts[:duty_expression_id] = "01"
+        opts[:duty_expression_description] = "test"
+        opts[:duty_amount] = 30
+        DutyExpressionFormatter.format(opts).should == "30.00 test"
       end
     end
 
     context 'monetary unit is present' do
       it 'gets included into formatted result' do
-        DutyExpressionFormatter.format("01", "test", 30, "EUR", nil, nil).should == "30.00 test EUR"
+        opts[:duty_expression_id] = "01"
+        opts[:duty_amount] = 30
+        opts[:duty_expression_description] = "test"
+        opts[:monetary_unit] = "EUR"
+        DutyExpressionFormatter.format(opts).should == "30.00 test EUR"
       end
     end
 
     context 'measurement unit is present' do
       it 'gets included into formatted result' do
-        DutyExpressionFormatter.format("01", "test", 30, "EUR", "KG", nil).should == "30.00 test EUR/KG"
+        opts[:duty_expression_id] = "01"
+        opts[:duty_amount] = 30
+        opts[:duty_expression_description] = "test"
+        opts[:monetary_unit] = "EUR"
+        opts[:measurement_unit] = "KG"
+        DutyExpressionFormatter.format(opts).should == "30.00 test EUR/KG"
       end
     end
 
     context 'measurement unit qualifier is present' do
       it 'gets included into formatted result' do
-        DutyExpressionFormatter.format("01", "test", 30, "EUR", "KG", "L").should == "30.00 test EUR/KG L"
+        opts[:duty_expression_id] = "01"
+        opts[:duty_amount] = 30
+        opts[:duty_expression_description] = "test"
+        opts[:monetary_unit] = "EUR"
+        opts[:measurement_unit] = "KG"
+        opts[:measurement_unit_qualifier] = "L"
+        DutyExpressionFormatter.format(opts).should == "30.00 test EUR/KG L"
       end
     end
   end


### PR DESCRIPTION
This means that for one field formatters its a bit ugly, but its better for ones with more fields. 

I had an issue with the Chapter to_s method I needed to use a different method name, this needs checking in other places.
