### PR TITLE
Fix MeasureCondition duty expression formatting issues.

### DIFF
--- a/app/formatters/description_formatter.rb
+++ b/app/formatters/description_formatter.rb
@@ -1,6 +1,8 @@
 class DescriptionFormatter
   def self.format(opts = {})
-    str = opts[:description]
+    raise ArgumentError.new("DescriptionFormatter expects :using arg to be a single value") if opts.keys.many?
+
+    str = opts.values.first
     str.gsub!("|", "&nbsp;")
     str.gsub!("!1!", "<br />")
     str.gsub!("!X!", "&times;")

--- a/app/formatters/description_trim_formatter.rb
+++ b/app/formatters/description_trim_formatter.rb
@@ -1,6 +1,8 @@
 class DescriptionTrimFormatter
   def self.format(opts={})
-    str = opts[:description]
+    raise ArgumentError.new("DescriptionFormatter expects :using arg to be a single value") if opts.keys.many?
+
+    str = opts.values.first
     str.gsub!("|", " ")
     str.gsub!("!1!", "")
     str.gsub!("!X!", "")

--- a/app/formatters/duty_expression_formatter.rb
+++ b/app/formatters/duty_expression_formatter.rb
@@ -1,7 +1,7 @@
 class DutyExpressionFormatter
 
   def self.prettify(float)
-    float.to_i == float ? float.to_i : float
+    sprintf("%.2f", float)
   end
 
   def self.format(opts={})
@@ -11,7 +11,7 @@ class DutyExpressionFormatter
     duty_amount = opts[:duty_amount]
     monetary_unit = opts[:monetary_unit]
     measurement_unit = opts[:measurement_unit]
-    measurement_unit_qualifier = opts[:measurement_unit_qualifier]
+    measurement_unit_qualifier = opts[:formatted_measurement_unit_qualifier]
 
     output = []
 

--- a/app/formatters/requirement_duty_expression_formatter.rb
+++ b/app/formatters/requirement_duty_expression_formatter.rb
@@ -1,0 +1,27 @@
+class RequirementDutyExpressionFormatter
+  def self.prettify(float)
+    sprintf("%.2f", float)
+  end
+
+  def self.format(opts={})
+    duty_amount = opts[:duty_amount]
+    monetary_unit = opts[:monetary_unit]
+    measurement_unit = opts[:measurement_unit]
+    measurement_unit_qualifier = opts[:formatted_measurement_unit_qualifier]
+
+    output = []
+
+    if duty_amount.present?
+      output << prettify(duty_amount).to_s
+    end
+
+    if monetary_unit.present? && measurement_unit.present? && measurement_unit_qualifier.present?
+      output << "#{monetary_unit}/(#{measurement_unit}/#{measurement_unit_qualifier})"
+    elsif monetary_unit.present? && measurement_unit.present?
+      output << "#{monetary_unit}/#{measurement_unit}"
+    elsif measurement_unit.present?
+      output << measurement_unit
+    end
+    output.join(" ").html_safe
+  end
+end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -10,16 +10,15 @@ class Chapter
   has_one :section
   has_many :headings
 
-  format :description, with: DescriptionFormatter,
-                       using: [:description],
-                       as: :formatted_decription
+  format :formatted_description, with: DescriptionFormatter,
+                                using: :description
 
   delegate :numeral, to: :section, prefix: true
 
   alias :code :goods_nomenclature_item_id
 
   def to_s
-    formatted_decription.mb_chars.downcase.to_s.gsub(/^(.)/) { $1.capitalize }
+    formatted_description.mb_chars.downcase.to_s.gsub(/^(.)/) { $1.capitalize }
   end
 
   def short_code

--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -15,12 +15,10 @@ module Models
 
       attr_accessor :description, :goods_nomenclature_item_id, :producline_suffix, :number_indents, :goods_nomenclature_sid, :bti_url
 
-      format :description, with: DescriptionTrimFormatter,
-                           using: [:description],
-                           as: :description_plain
-      format :description, with: DescriptionFormatter,
-                           using: [:description],
-                           as: :formatted_description
+      format :description_plain, with: DescriptionTrimFormatter,
+                                 using: :description
+      format :formatted_description, with: DescriptionFormatter,
+                                     using: :description
 
       delegate :numeral, to: :section, prefix: true
       delegate :code, :short_code, to: :chapter, prefix: true

--- a/app/models/footnote.rb
+++ b/app/models/footnote.rb
@@ -7,7 +7,8 @@ class Footnote
 
   attr_accessor :code, :description
 
-  format :description, with: DescriptionFormatter, using: [:description]
+  format :formatted_description, with: DescriptionFormatter,
+                                using: :description
 
   def id
     @id ||= SecureRandom.hex(16)

--- a/app/models/measure_component.rb
+++ b/app/models/measure_component.rb
@@ -8,8 +8,11 @@ class MeasureComponent
   attr_accessor :duty_amount, :duty_expression_id, :duty_expression_description,
                 :duty_expression_abbreviation, :monetary_unit, :measurement_unit, :measurement_unit_qualifier
 
+  format :measurement_unit_qualifier, with: DescriptionFormatter,
+                                     using: :formatted_measurement_unit_qualifier
+
   format :duty_expression, with: DutyExpressionFormatter,
                            using: [:duty_expression_id, :duty_expression_description, :duty_amount,
                                    :duty_expression_abbreviation, :monetary_unit, :measurement_unit,
-                                   :measurement_unit_qualifier]
+                                   :formatted_measurement_unit_qualifier]
 end

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -2,6 +2,7 @@ require 'api_entity'
 
 class MeasureCondition
   include ApiEntity
+  include Models::Formatter
 
   has_one  :requirement, class: 'MeasureCondition::Requirement'
   has_many :components,  class: 'MeasureCondition::Component'

--- a/app/models/measure_condition/component.rb
+++ b/app/models/measure_condition/component.rb
@@ -9,8 +9,12 @@ class MeasureCondition
     attr_accessor :duty_expression_id, :duty_expression_description, :duty_expression_abbreviation,
                   :duty_amount, :monetary_unit, :measurement_unit, :measurement_unit_qualifier
 
+    format :formatted_measurement_unit_qualifier, with: DescriptionFormatter,
+                                                  using: :measurement_unit_qualifier
+
+
     format :duty_expression, with: DutyExpressionFormatter,
                              using: [:duty_expression_id, :duty_expression_description, :duty_expression_abbreviation,
-                                     :duty_amount, :monetary_unit, :measurement_unit, :measurement_unit_qualifier]
+                                     :duty_amount, :monetary_unit, :measurement_unit, :formatted_measurement_unit_qualifier]
   end
 end

--- a/app/models/measure_condition/requirement.rb
+++ b/app/models/measure_condition/requirement.rb
@@ -10,16 +10,15 @@ class MeasureCondition
                   :measurement_unit, :measurement_unit_qualifier, :certificate,
                   :certificate_type
 
-    format :duty_expression, with: DutyExpressionFormatter,
-                             using: [:duty_expression_id, :duty_expression_description,
-                                     :duty_amount,
-                                     :duty_expression_abbreviation,
-                                     :monetary_unit, :measurement_unit,
-                                     :measurement_unit_qualifier],
-                             defaults: {
-                                      duty_expression_id: '01'
-                                    },
-                             as: :duty_expression
+
+    format :formatted_measurement_unit_qualifier, with: DescriptionFormatter,
+                                                  using: :measurement_unit_qualifier
+
+    format :duty_expression, with: RequirementDutyExpressionFormatter,
+                             using: [:duty_amount,
+                                     :monetary_unit,
+                                     :measurement_unit,
+                                     :formatted_measurement_unit_qualifier]
 
     def to_s
       "#{certificate_type}: #{certificate}"

--- a/app/views/footnotes/_footnote.html.erb
+++ b/app/views/footnotes/_footnote.html.erb
@@ -1,4 +1,4 @@
 <tr>
   <td><%= footnote.code %></td>
-  <td><%= simple_format footnote.description %></td>
+  <td><%= simple_format footnote.formatted_description %></td>
 </tr>

--- a/app/views/measure_conditions/_measure_condition.html.erb
+++ b/app/views/measure_conditions/_measure_condition.html.erb
@@ -19,6 +19,6 @@
   </td>
   <td><%= measure_condition.action %></td>
   <td>
-    <%= measure_condition.duty_expression %>
+    <%= raw measure_condition.duty_expression %>
   </td>
 </tr>

--- a/spec/formatters/duty_expression_formatter_spec.rb
+++ b/spec/formatters/duty_expression_formatter_spec.rb
@@ -61,7 +61,7 @@ describe DutyExpressionFormatter do
         it 'result includes measurement unit and measurement unit qualifier' do
           DutyExpressionFormatter.format(duty_expression_id: '15',
                                          measurement_unit: 'KG',
-                                         measurement_unit_qualifier: 'L',
+                                         formatted_measurement_unit_qualifier: 'L',
                                          duty_expression_description: 'abc').should =~ /\/ \(KG\/L\)/
         end
       end
@@ -119,7 +119,7 @@ describe DutyExpressionFormatter do
         it 'result includes measurement unit and measurement unit qualifier' do
           DutyExpressionFormatter.format(duty_expression_id: '66',
                                          measurement_unit: 'KG',
-                                         measurement_unit_qualifier: 'L',
+                                         formatted_measurement_unit_qualifier: 'L',
                                          duty_expression_description: 'abc').should =~ /\/ \(KG\/L\)/
         end
       end

--- a/spec/formatters/requirement_duty_expression_formatter_spec.rb
+++ b/spec/formatters/requirement_duty_expression_formatter_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+require 'requirement_duty_expression_formatter'
+
+describe RequirementDutyExpressionFormatter do
+  describe '.format' do
+    context 'duty amount present' do
+      it 'result includes duty amount' do
+        RequirementDutyExpressionFormatter.format(duty_amount: '55').should =~ /55/
+      end
+    end
+
+    context 'monetary unit, measurement unit & measurement_unit_qualifier are present ' do
+      subject {
+        RequirementDutyExpressionFormatter.format(measurement_unit: 'Tonne',
+                                                  formatted_measurement_unit_qualifier: 'L',
+                                                  monetary_unit: 'EUR')
+      }
+
+      it 'properly formats output' do
+        subject.should =~ /EUR\/\(Tonne\/L\)/
+      end
+    end
+
+    context 'monetary unit and measurement unit are present' do
+      subject {
+        RequirementDutyExpressionFormatter.format(monetary_unit: 'EUR',
+                                                  measurement_unit: 'KG')
+      }
+
+      it 'properly formats result' do
+        subject.should =~ /EUR\/KG/
+      end
+    end
+
+    context 'measurement unit is present' do
+      subject {
+        RequirementDutyExpressionFormatter.format(measurement_unit: 'KG')
+      }
+
+      it 'properly formats output' do
+        subject.should =~ /KG/
+      end
+    end
+  end
+end

--- a/spec/requests/commodity_spec.rb
+++ b/spec/requests/commodity_spec.rb
@@ -4,7 +4,7 @@ describe 'Commodity page' do
   it 'displays declarable related information', vcr: { cassette_name: "commodities#show" } do
     visit commodity_path("0101300000")
 
-    page.should have_content 'Importing from outside the EU is subject to a third country duty of 7.7 %'
+    page.should have_content 'Importing from outside the EU is subject to a third country duty of 7.70 %'
     page.should have_content 'Goods are subject to VAT standard rate.'
   end
 end

--- a/spec/requests/heading_spec.rb
+++ b/spec/requests/heading_spec.rb
@@ -5,7 +5,7 @@ describe 'Heading page' do
     it 'displays declarable related information' do
       visit heading_path("0501")
 
-      page.should have_content 'Importing from outside the EU is subject to a third country duty of 0 %.'
+      page.should have_content 'Importing from outside the EU is subject to a third country duty of 0.00 %.'
       page.should have_content 'Goods are subject to VAT standard rate.'
     end
   end


### PR DESCRIPTION
This enables Formatter to call methods along with fetching values from attributes hash. Fixes duty formatting issues on MeasureConditions, e.g.:

('view conditions' on All destinations - export refund 9100)
https://www.gov.uk/trade-tariff/commodities/1102903000?as_of=2012-10-02#export
vs
http://tariff.business.wales.gov.uk/tariff-bl/export/commoditycode.html?export=true&simulationDate=22/10/12&id=11029030&additionalCode1=&additionalCode2=&additionalCode3=&countryCode=

There will be no / or % sign in duty.

('view conditions' on Autonomous suspension under end use F073)
https://www.gov.uk/trade-tariff/commodities/0302511020#import
vs
http://tariff.business.wales.gov.uk/tariff-bl/export/commoditycode.html?export=false&from=heading&id=0302511020&simulationDate=22/10/12

Properly states '1161.00 EUR/Tonne'.

('view conditions' on Additional duty based on cif price)
https://www.gov.uk/trade-tariff/commodities/1702909500#import
vs
http://tariff.business.wales.gov.uk/tariff-bl/export/commoditycode.html?export=false&simulationDate=22/10/12&id=1702909500&additionalCode1=&additionalCode2=&additionalCode3=&countryCode=

No '|' marks, properly formatted expressions.

This fixes #37711475 in Pivotal.
