### PR TITLE
Add monetary unit abbreviation support.

### DIFF
--- a/app/formatters/duty_expression_formatter.rb
+++ b/app/formatters/duty_expression_formatter.rb
@@ -9,7 +9,7 @@ class DutyExpressionFormatter
     duty_expression_description = opts[:duty_expression_description]
     duty_expression_abbreviation = opts[:duty_expression_abbreviation]
     duty_amount = opts[:duty_amount]
-    monetary_unit = opts[:monetary_unit]
+    monetary_unit = opts[:monetary_unit_abbreviation].presence || opts[:monetary_unit]
     measurement_unit = opts[:measurement_unit]
     measurement_unit_qualifier = opts[:formatted_measurement_unit_qualifier]
 

--- a/app/formatters/requirement_duty_expression_formatter.rb
+++ b/app/formatters/requirement_duty_expression_formatter.rb
@@ -5,7 +5,7 @@ class RequirementDutyExpressionFormatter
 
   def self.format(opts={})
     duty_amount = opts[:duty_amount]
-    monetary_unit = opts[:monetary_unit]
+    monetary_unit = opts[:monetary_unit_abbreviation].presence || opts[:monetary_unit]
     measurement_unit = opts[:measurement_unit]
     measurement_unit_qualifier = opts[:formatted_measurement_unit_qualifier]
 

--- a/app/models/measure_component.rb
+++ b/app/models/measure_component.rb
@@ -5,14 +5,25 @@ class MeasureComponent
   include ApiEntity
   include Models::Formatter
 
-  attr_accessor :duty_amount, :duty_expression_id, :duty_expression_description,
-                :duty_expression_abbreviation, :monetary_unit, :measurement_unit, :measurement_unit_qualifier
+  attr_accessor :duty_amount,
+                :duty_expression_id,
+                :duty_expression_description,
+                :duty_expression_abbreviation,
+                :monetary_unit,
+                :monetary_unit_abbreviation,
+                :measurement_unit,
+                :measurement_unit_qualifier
 
   format :measurement_unit_qualifier, with: DescriptionFormatter,
                                      using: :formatted_measurement_unit_qualifier
 
   format :duty_expression, with: DutyExpressionFormatter,
-                           using: [:duty_expression_id, :duty_expression_description, :duty_amount,
-                                   :duty_expression_abbreviation, :monetary_unit, :measurement_unit,
+                           using: [:duty_expression_id,
+                                   :duty_expression_description,
+                                   :duty_amount,
+                                   :duty_expression_abbreviation,
+                                   :monetary_unit,
+                                   :monetary_unit_abbreviation,
+                                   :measurement_unit,
                                    :formatted_measurement_unit_qualifier]
 end

--- a/app/models/measure_condition/component.rb
+++ b/app/models/measure_condition/component.rb
@@ -6,15 +6,27 @@ class MeasureCondition
     include ApiEntity
     include Models::Formatter
 
-    attr_accessor :duty_expression_id, :duty_expression_description, :duty_expression_abbreviation,
-                  :duty_amount, :monetary_unit, :measurement_unit, :measurement_unit_qualifier
+    attr_accessor :duty_expression_id,
+                  :duty_expression_description,
+                  :duty_expression_abbreviation,
+                  :duty_amount,
+                  :monetary_unit,
+                  :monetary_unit_abbreviation,
+                  :measurement_unit,
+                  :measurement_unit_qualifier
 
     format :formatted_measurement_unit_qualifier, with: DescriptionFormatter,
                                                   using: :measurement_unit_qualifier
 
 
     format :duty_expression, with: DutyExpressionFormatter,
-                             using: [:duty_expression_id, :duty_expression_description, :duty_expression_abbreviation,
-                                     :duty_amount, :monetary_unit, :measurement_unit, :formatted_measurement_unit_qualifier]
+                             using: [:duty_expression_id,
+                                     :duty_expression_description,
+                                     :duty_expression_abbreviation,
+                                     :duty_amount,
+                                     :monetary_unit,
+                                     :monetary_unit_abbreviation,
+                                     :measurement_unit,
+                                     :formatted_measurement_unit_qualifier]
   end
 end

--- a/app/models/measure_condition/requirement.rb
+++ b/app/models/measure_condition/requirement.rb
@@ -6,8 +6,13 @@ class MeasureCondition
     include ApiEntity
     include Models::Formatter
 
-    attr_accessor :sequence_number, :duty_amount, :monetary_unit,
-                  :measurement_unit, :measurement_unit_qualifier, :certificate,
+    attr_accessor :sequence_number,
+                  :duty_amount,
+                  :monetary_unit,
+                  :monetary_unit_abbreviation,
+                  :measurement_unit,
+                  :measurement_unit_qualifier,
+                  :certificate,
                   :certificate_type
 
 
@@ -17,6 +22,7 @@ class MeasureCondition
     format :duty_expression, with: RequirementDutyExpressionFormatter,
                              using: [:duty_amount,
                                      :monetary_unit,
+                                     :monetary_unit_abbreviation,
                                      :measurement_unit,
                                      :formatted_measurement_unit_qualifier]
 


### PR DESCRIPTION
For some monetary units we need to display their alternative names, like EUC = EUR (EUC).

So display monetary unit abbreviation if its present and then revert to monetary unit otherwise.

This goes along with https://github.com/alphagov/trade-tariff-backend/pull/22.
