### PR TITLE
Remove exception notification initializer

### DIFF
--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,6 +1,0 @@
-unless Rails.env.development? or Rails.env.test?
-  Rails.application.config.middleware.use ExceptionNotifier,
-    email_prefix: "[#{Rails.application.class.name.split('::').first} (#{Plek.current.environment})] ",
-    sender_address: %{"Winston Smith-Churchill" <winston@alphagov.co.uk>},
-    exception_recipients: %w{govuk-exceptions@digital.cabinet-office.gov.uk}
-end


### PR DESCRIPTION
There's no need for this if the initializers are provided at deploy-time.
Once alphagov/alphagov-deployment#58 gets merged, that will be true.
