### PR TITLE
Fix third country duty rate picking.

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -28,8 +28,13 @@ module Models
       goods_nomenclature_item_id
     end
 
+    def third_country_duty_measures
+      import_measures.select(&:third_country_duty)
+    end
+
     def third_country_duty
-      import_measures.select(&:third_country_duty).first
+      third_country_duty_measures.sort_by(&:additional_code_code)
+                                 .last
     end
 
     def third_country_duty_rate

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -16,6 +16,7 @@ class Measure
   has_many :footnotes
 
   delegate :description, :group_key, to: :geographical_area, prefix: true
+  delegate :code, to: :additional_code, prefix: true, allow_nil: true
 
   def id
     @id ||= SecureRandom.hex(16)
@@ -108,5 +109,9 @@ class Measure
 
   def vat?
     measure_type_description =~ /^VAT/
+  end
+
+  def additional_code
+    @additional_code.presence || NullObject.new(code: '')
   end
 end

--- a/app/presenters/declarable_presenter.rb
+++ b/app/presenters/declarable_presenter.rb
@@ -24,8 +24,7 @@ class DeclarablePresenter
   end
 
   def import_measures_for_third_country
-    declarable.import_measures
-              .select(&:third_country)
+    declarable.third_country_duty_measures
               .sort_by(&:sort_key)
               .present_with(MeasurePresenter)
   end

--- a/lib/null_object.rb
+++ b/lib/null_object.rb
@@ -1,5 +1,16 @@
+# stub_attrs can be used to assign default values for method calls.
+# Useful in cases where comparison with nil may occur.
 class NullObject
+  def initialize(stub_attrs = {})
+    @stub_attrs = stub_attrs
+  end
+
+  def empty?; true; end
+  def blank?; true; end
+
   def method_missing(*args, &block)
-    nil
+    method_name = args.first
+
+    @stub_attrs.fetch(method_name, nil)
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -38,6 +38,7 @@ FactoryGirl.define do
     end
 
     trait :third_country do
+      measure_type_id { '103' }
       geographical_area { attributes_for(:geographical_area, :third_country) }
     end
 

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -82,4 +82,29 @@ describe Commodity do
       non_consigned_commodity.consigned_from.should be_blank
     end
   end
+
+  describe 'third country duty rate fetch' do
+    let(:measure1)      { attributes_for :measure, :third_country, measure_type_description: 'abc', additional_code: { code: '123' } }
+    let(:measure2)      { attributes_for :measure, :third_country, measure_type_description: 'def', additional_code: { code: '456' } }
+    let(:measure3)      { attributes_for :measure, measure_type_id: '911', measure_type_description: 'xyz' }
+    let(:measures)      { [measure1, measure2, measure3] }
+    let(:commodity)     { Commodity.new(attributes_for :commodity, import_measures: measures) }
+
+    describe '#third_country_duty_measures' do
+      it 'picks only commodities that qualify for third country duty' do
+        commodity.third_country_duty_measures.map(&:measure_type_description).should include 'abc'
+        commodity.third_country_duty_measures.map(&:measure_type_description).should include 'def'
+      end
+
+      it 'does not pick other measures' do
+        commodity.third_country_duty_measures.map(&:measure_type_description).should_not include 'xyz'
+      end
+    end
+
+    describe '#third_country_duty' do
+      it 'sorts commodities by additional code and picks the last one' do
+        commodity.third_country_duty.measure_type_description.should eq 'def'
+      end
+    end
+  end
 end


### PR DESCRIPTION
If there are more than two measures with the same duty expression that
represent third country duty rate sort them by additional code and pick
last one.

Fixes https://www.gov.uk/trade-tariff/commodities/3824909799. Should
show 6.5% instead of 0.0%.
