### PR TITLE
Handle additional consigned from cases

### DIFF
--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -43,11 +43,11 @@ class Commodity
 
   # There are no consigned declarable headings
   def consigned?
-    description =~ /Consigned from/i
+    description =~ /consigned from/i
   end
 
   def consigned_from
-    description.match(/Consigned from (.*)/)[1] if consigned?
+    description.scan(/consigned from ([a-zA-Z,' ]+)(?:\W|$)/i).join(", ") if consigned?
   end
 
   def to_param

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -76,15 +76,34 @@ describe Commodity do
   end
 
   describe '#consigned_from' do
-    let(:consigned_commodity)     { Commodity.new(attributes_for :commodity, description: 'Consigned from Malaysia') }
-    let(:non_consigned_commodity) { Commodity.new(attributes_for :commodity) }
-
     it 'returns country name' do
-      consigned_commodity.consigned_from.should eq 'Malaysia'
+      commodity = Commodity.new(attributes_for :commodity, description: 'Consigned from Malaysia')
+      commodity.consigned_from.should eq 'Malaysia'
     end
 
     it 'returns blank value for non consigned commodity' do
-      non_consigned_commodity.consigned_from.should be_blank
+      commodity = Commodity.new(attributes_for :commodity, description: 'from Malaysia')
+      commodity.consigned_from.should be_blank
+    end
+
+    it 'should handle multiple consignments' do
+      commodity = Commodity.new(attributes_for :commodity, description: 'Consigned from Brazil; consigned from Israel')
+      commodity.consigned_from.should eq 'Brazil, Israel'
+    end
+
+    it 'should handle consignments from countries will names of few words' do
+      commodity = Commodity.new(attributes_for :commodity, description: 'Consigned from the Republic of Korea')
+      commodity.consigned_from.should eq 'the Republic of Korea'
+    end
+
+    it 'should handle consignments from multiple listed countries' do
+      commodity = Commodity.new(attributes_for :commodity, description: 'Consigned from Taiwan, Indonesia, Sri Lanka or the Philippines')
+      commodity.consigned_from.should eq 'Taiwan, Indonesia, Sri Lanka or the Philippines'
+    end
+
+    it 'should handle consignments from countries that have names with apostrophes' do
+      commodity = Commodity.new(attributes_for :commodity, description: "Consigned from Lao People's Democratic Republic")
+      commodity.consigned_from.should eq "Lao People's Democratic Republic"
     end
   end
 


### PR DESCRIPTION
Current implementation is limited to single word (country name supposedly) after 'Consigned from ', like here https://www.gov.uk/trade-tariff/commodities/1518009921. But there are other cases with multiple countries or countries that have names of multiple words, see here https://www.gov.uk/trade-tariff/search?utf8=%E2%9C%93&q=trade_tariff&t=consigned&as_of=&button=.

This change makes them display properly.
