### PR TITLE
Make form contain floating children

### DIFF
--- a/app/assets/stylesheets/tariff.scss
+++ b/app/assets/stylesheets/tariff.scss
@@ -496,6 +496,7 @@ article.tariff {
   line-height:2em;
   background:#fff;
   padding:0 px($top-level-padding) 1em px($token-space);
+  @include contain-float;
 
   p {
     display:inline;
@@ -516,14 +517,10 @@ article.tariff {
   fieldset {
     float: left;
     width: 49%;
-  }
 
-  &:after {
-    content: "\0020";
-    display: block;
-    height: 0;
-    overflow: hidden;
-    clear: both;
+    &.relevant-links {
+      clear: both; 
+    }
   }
 }
 


### PR DESCRIPTION
The main form contained fieldsets that were not being contained properly (without a [haslayout](http://www.satzansatz.de/cssd/onhavinglayout.html) fix). This adds CSS for IE to contain them.
