### PR TITLE
Commodity footnotes moved to separate table.

### DIFF
--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -227,8 +227,25 @@
   </article><!-- end .tab-pane -->
   <article class='tab-pane' id='footnotes' data-id="<%= declarable.to_param %>" data-class="<%=declarable.class.name.downcase.pluralize %>">
     <div class="inner">
+      <% if declarable.footnote.present? %>
+        <table>
+          <caption>Footnotes for commodity:</caption>
+          <thead>
+            <tr>
+              <th>Code</th>
+
+              <th>Description</th>
+            </tr>
+          </thead>
+
+          <tbody>
+              <%= render declarable.footnote %>
+          </tbody>
+        </table>
+      <% end %>
+
       <table>
-        <caption>Footnotes for commodity:</caption>
+        <caption>Footnotes for measures:</caption>
         <thead>
           <tr>
             <th>Code</th>
@@ -238,9 +255,6 @@
         </thead>
 
         <tbody>
-          <% if declarable.footnote.present? %>
-            <%= render declarable.footnote %>
-          <% end %>
           <%= render declarable.footnotes %>
         </tbody>
       </table>


### PR DESCRIPTION
This change is for https://www.pivotaltracker.com/story/show/42351465. Commodity footnotes have their own table in 'Footnotes' section.
