### PR TITLE
Fix third country measure matching.

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -57,11 +57,11 @@ class Measure
   end
 
   def third_country
-    geographical_area.description == "ERGA OMNES"
+    geographical_area.geographical_area_id == '1011'
   end
 
   def for_specific_countries
-    geographical_area.description != "ERGA OMNES"
+    !third_country
   end
 
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -64,7 +64,7 @@ FactoryGirl.define do
     description { Forgery(:basic).text }
 
     trait :third_country do
-      description { "ERGA OMNES" }
+      geographical_area_id { "1011" }
     end
 
     trait :specific_country do

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -32,4 +32,17 @@ describe Measure do
       measure.relevant_for_country?('lt').should eq false
     end
   end
+
+  describe '#third_country' do
+    let(:measure1) { Measure.new(attributes_for(:measure, geographical_area: {geographical_area_id: '1011' })) }
+    let(:measure2) { Measure.new(attributes_for(:measure, geographical_area: {geographical_area_id: '103'  })) }
+
+    it 'returns true if geographical area' do
+      measure1.third_country.should be_true
+    end
+
+    it 'returns false if country name does not contain ERGA OMNES' do
+      measure2.third_country.should be_false
+    end
+  end
 end


### PR DESCRIPTION
ERGA OMNES countries have geographical area id equal to 1011. That includes ERGA OMNES and ERGA OMNES-CEE.

This patch should move ERGA OMNES-CEE measures to Third country table here https://www.gov.uk/trade-tariff/commodities/0101110000?day=1&month=1&year=1998#import.
