### PR TITLE
Add fix for lists in IE8

### DIFF
--- a/app/assets/stylesheets/tariff.scss
+++ b/app/assets/stylesheets/tariff.scss
@@ -211,12 +211,19 @@ $expand-arrow-space: 9 + $token-padding;
 }
 
 @mixin underlined-token-list {
-  dt,
+  /* IE8 is not recognising selector blocks including nth-child so they are separate here */
+  dt {
+    border-top:1px solid #fff;
+  }
+
   dl dt:nth-child(1) {
     border-top:1px solid #fff;
   }
 
-  dd,
+  dd {
+    border-top:1px solid #eee;
+  }
+
   dl dd:nth-child(2) {
     border-top:1px solid #eee;
   }


### PR DESCRIPTION
CSS for the lists across tariff uses the nth-child selector. This should fall back to a less exact version for IE<8 but use of the selector caused selector blocks including CSS for all to be ignored.

Split the two types of selector out to fix this.
