### PR TITLE
Rename Legal Act column on Measure listing

### DIFF
--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -75,7 +75,7 @@
 
             <th scope="col">Exclusions</th>
 
-            <th scope="col" class="legal-act external-link" title="Opens in a new window">Legal act</th>
+            <th scope="col" class="legal-act external-link" title="Opens in a new window">ECC Regulation</th>
 
             <th scope="col">Footnote</th>
           </tr>
@@ -111,7 +111,7 @@
 
               <th>Exclusions</th>
 
-              <th class="legal-act external-link" title="Opens in a new window">Legal act</th>
+              <th class="legal-act external-link" title="Opens in a new window">ECC Regulation</th>
 
               <th>Footnotes</th>
             </tr>
@@ -156,7 +156,7 @@
 
             <th>Exclusions</th>
 
-            <th class="legal-act external-link" title="Opens in a new window">Legal act</th>
+            <th class="legal-act external-link" title="Opens in a new window">ECC Regulation</th>
 
             <th>Footnotes</th>
           </tr>
@@ -205,7 +205,7 @@
 
             <th scope="col">Exclusions</th>
 
-            <th scope="col" class="legal-act external-link" title="Opens in a new window">Legal act</th>
+            <th scope="col" class="legal-act external-link" title="Opens in a new window">ECC Regulation</th>
 
             <th scope="col">Footnote</th>
           </tr>
@@ -253,7 +253,7 @@
 
               <th>Exclusions</th>
 
-              <th class="legal-act external-link" title="Opens in a new window">Legal act</th>
+              <th class="legal-act external-link" title="Opens in a new window">ECC Regulation</th>
 
               <th>Footnotes</th>
             </tr>
@@ -298,7 +298,7 @@
 
             <th>Exclusions</th>
 
-            <th class="legal-act external-link" title="Opens in a new window">Legal act</th>
+            <th class="legal-act external-link" title="Opens in a new window">ECC Regulation</th>
 
             <th>Footnotes</th>
           </tr>


### PR DESCRIPTION
It is now called ECC Regulation.

This change is for https://www.pivotaltracker.com/story/show/46283643.
