### PR TITLE
Strip range search brackets from search term.

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -18,6 +18,10 @@ class Search
     Outcome.new(response)
   end
 
+  def t=(t)
+    @t = t.to_s.gsub(/(\[|\])/,'')
+  end
+
   def q
     'trade_tariff'
   end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -1,7 +1,10 @@
 require 'spec_helper'
 
 describe Search do
-  subject { Search }
+  it 'strips [ and ] characters from search term' do
+    search = Search.new(t: '[hello] [world]')
+    search.t.should eq 'hello world'
+  end
 
   it 'raises on error if search responds with status 500' do
     response_stub = stub(code: 500)


### PR DESCRIPTION
This is accompanying change for https://github.com/alphagov/trade-tariff-backend/pull/79.

Makes sure that the user also sees the search term stripped.
