### PR TITLE
Fix measurement unit qualifier display

### DIFF
--- a/app/formatters/description_formatter.rb
+++ b/app/formatters/description_formatter.rb
@@ -3,6 +3,7 @@ class DescriptionFormatter
     raise ArgumentError.new("DescriptionFormatter expects :using arg to be a single value") if opts.keys.many?
 
     str = opts.values.first
+    str.gsub!("|%", "%")
     str.gsub!(/&(\w+|\s+)/, '&amp;\1')
     str.gsub!("|", "&nbsp;")
     str.gsub!("!1!", "<br />")

--- a/app/models/measure_component.rb
+++ b/app/models/measure_component.rb
@@ -14,8 +14,8 @@ class MeasureComponent
                 :measurement_unit,
                 :measurement_unit_qualifier
 
-  format :measurement_unit_qualifier, with: DescriptionFormatter,
-                                     using: :formatted_measurement_unit_qualifier
+  format :formatted_measurement_unit_qualifier, with: DescriptionFormatter,
+                                                using: :measurement_unit_qualifier
 
   format :duty_expression, with: DutyExpressionFormatter,
                            using: [:duty_expression_id,

--- a/spec/models/measure_component_spec.rb
+++ b/spec/models/measure_component_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe MeasureComponent do
+  describe '#duty_expression' do
+    context 'with measurement unit qualifier' do
+      let(:measure_component) {
+        MeasureComponent.new(
+          duty_amount: 0.4,
+          duty_expression_id: "01",
+          duty_expression_description: "% (Amount)",
+          duty_expression_abbreviation: "%",
+          monetary_unit: "EUR",
+          monetary_unit_abbreviation: nil,
+          measurement_unit: "Hectokilogram",
+          measurement_unit_qualifier: "Per 1|% by weight of sucrose"
+        )
+      }
+
+      it 'correctly formats duty expression' do
+        measure_component.duty_expression.should eq '0.40 EUR / (Hectokilogram/Per 1% by weight of sucrose)'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Measurement unit qualifier is now included in duty expression.

This change is for https://www.pivotaltracker.com/story/show/46443953.

After deploy we expect Third country duty in the following commodity (https://www.gov.uk/trade-tariff/commodities/1702201000?country=&day=19&month=3&year=2013#import) to have the following duty expression: "0.40 EUR / (Hectokilogram/Per 1% by weight of sucrose)".

EU Taric uses abbreviations, we display full description for now.
