### PR TITLE
Enhance description formatting

### DIFF
--- a/app/formatters/description_formatter.rb
+++ b/app/formatters/description_formatter.rb
@@ -4,8 +4,8 @@ class DescriptionFormatter
 
     str = opts.values.first
     str.gsub!("|%", "%")
-    str.gsub!(/&(\w+|\s+)/, '&amp;\1')
     str.gsub!("|", "&nbsp;")
+    str.gsub!(/&(?!#|nbsp)/, '&amp;')
     str.gsub!("!1!", "<br />")
     str.gsub!("!X!", "&times;")
     str.gsub!("!x!", "&times;")

--- a/app/models/footnote.rb
+++ b/app/models/footnote.rb
@@ -8,7 +8,7 @@ class Footnote
   attr_accessor :code, :description
 
   format :formatted_description, with: DescriptionFormatter,
-                                using: :description
+                                 using: :description
 
   def id
     @id ||= "#{casted_by.destination}-#{casted_by.id}-footnote-#{code}"

--- a/spec/formatters/description_formatter_spec.rb
+++ b/spec/formatters/description_formatter_spec.rb
@@ -3,44 +3,62 @@ require 'description_formatter'
 
 describe DescriptionFormatter do
   describe '.format' do
+    it 'replaces & with ampersands' do
+      description = 'bread & butter'
+
+      DescriptionFormatter.format(description: description).should eq 'bread &amp; butter'
+    end
+
+    it 'does not replace & followed with # (html entity)' do
+      description = '&#39;A&#39; with an &#39;X&#39;'
+
+      DescriptionFormatter.format(description: description).should eq description
+    end
+
+    it 'does not replace & followed by nbsp (non breaking space entity)' do
+      description = 'a&nbsp;paragraph'
+
+      DescriptionFormatter.format(description: description).should eq description
+    end
+
     it 'replaces | with non breaking space html entity' do
-      DescriptionFormatter.format(description: ' | ').should == ' &nbsp; '
+      DescriptionFormatter.format(description: ' | ').should eq ' &nbsp; '
     end
 
     it 'replaces !1! with breaking space tags' do
-      DescriptionFormatter.format(description: ' !1! ').should == ' <br /> '
+      DescriptionFormatter.format(description: ' !1! ').should eq ' <br /> '
     end
 
     it 'replaces !X! with times html entity' do
-      DescriptionFormatter.format(description: ' !X! ').should == ' &times; '
+      DescriptionFormatter.format(description: ' !X! ').should eq ' &times; '
     end
 
     it 'replaces !x! with times html entity' do
-      DescriptionFormatter.format(description: ' !x! ').should == ' &times; '
+      DescriptionFormatter.format(description: ' !x! ').should eq ' &times; '
     end
 
     it 'replaces !o! with deg html entity' do
-      DescriptionFormatter.format(description: ' !o! ').should == ' &deg; '
+      DescriptionFormatter.format(description: ' !o! ').should eq ' &deg; '
     end
 
     it 'replaces !O! with deg html entity' do
-      DescriptionFormatter.format(description: ' !O! ').should == ' &deg; '
+      DescriptionFormatter.format(description: ' !O! ').should eq ' &deg; '
     end
 
     it 'replaces !>=! with greater or equals html entity' do
-      DescriptionFormatter.format(description: ' !>=! ').should == ' &ge; '
+      DescriptionFormatter.format(description: ' !>=! ').should eq ' &ge; '
     end
 
     it 'replaces !<=! with less or equal html entity' do
-      DescriptionFormatter.format(description: ' !<=! ').should == ' &le; '
+      DescriptionFormatter.format(description: ' !<=! ').should eq ' &le; '
     end
 
     it 'replaces and wraps @<anycharacter> with html sub tag' do
-      DescriptionFormatter.format(description: ' @1 ').should == ' <sub>1</sub> '
+      DescriptionFormatter.format(description: ' @1 ').should eq ' <sub>1</sub> '
     end
 
     it 'replaces and wraps $<anycharacter> with html sup tag' do
-      DescriptionFormatter.format(description: ' $1 ').should == ' <sup>1</sup> '
+      DescriptionFormatter.format(description: ' $1 ').should eq ' <sup>1</sup> '
     end
   end
 end

--- a/spec/formatters/description_trim_formatter_spec.rb
+++ b/spec/formatters/description_trim_formatter_spec.rb
@@ -4,43 +4,43 @@ require 'description_trim_formatter'
 describe DescriptionTrimFormatter do
   describe '.format' do
     it 'replaces | with empty space' do
-      DescriptionTrimFormatter.format(description: '|').should == ' '
+      DescriptionTrimFormatter.format(description: '|').should eq ' '
     end
 
     it 'strips !1!' do
-      DescriptionTrimFormatter.format(description: '!1!').should == ''
+      DescriptionTrimFormatter.format(description: '!1!').should eq ''
     end
 
     it 'strips !X!' do
-      DescriptionTrimFormatter.format(description: '!X!').should == ''
+      DescriptionTrimFormatter.format(description: '!X!').should eq ''
     end
 
     it 'strips !x!' do
-      DescriptionTrimFormatter.format(description: '!x!').should == ''
+      DescriptionTrimFormatter.format(description: '!x!').should eq ''
     end
 
     it 'strips !o!' do
-      DescriptionTrimFormatter.format(description: '!o!').should == ''
+      DescriptionTrimFormatter.format(description: '!o!').should eq ''
     end
 
     it 'strips !O!' do
-      DescriptionTrimFormatter.format(description: '!O!').should == ''
+      DescriptionTrimFormatter.format(description: '!O!').should eq ''
     end
 
     it 'strips !>=!' do
-      DescriptionTrimFormatter.format(description: '!>=!').should == ''
+      DescriptionTrimFormatter.format(description: '!>=!').should eq ''
     end
 
     it 'strips !<=!' do
-      DescriptionTrimFormatter.format(description: '!<=!').should == ''
+      DescriptionTrimFormatter.format(description: '!<=!').should eq ''
     end
 
     it 'replaces  @<anycharacter> with <anycharacter>' do
-      DescriptionTrimFormatter.format(description: '@1').should == '1'
+      DescriptionTrimFormatter.format(description: '@1').should eq '1'
     end
 
     it 'replaces $<anycharacter> with <anycharacter>' do
-      DescriptionTrimFormatter.format(description: '$1').should == '1'
+      DescriptionTrimFormatter.format(description: '$1').should eq '1'
     end
   end
 end

--- a/spec/formatters/duty_expression_formatter_spec.rb
+++ b/spec/formatters/duty_expression_formatter_spec.rb
@@ -6,7 +6,7 @@ describe DutyExpressionFormatter do
     context 'for duty expression 99' do
       it 'return the measurement unit' do
         DutyExpressionFormatter.format(duty_expression_id: '99',
-                                       measurement_unit: 'abc').should == 'abc'
+                                       measurement_unit: 'abc').should eq 'abc'
       end
     end
 
@@ -15,14 +15,14 @@ describe DutyExpressionFormatter do
         it 'returns duty expression abbreviation' do
           DutyExpressionFormatter.format(duty_expression_id: '12',
                                          duty_expression_abbreviation: 'abc',
-                                         duty_expression_description: 'def').should == 'abc'
+                                         duty_expression_description: 'def').should eq 'abc'
         end
       end
 
       context 'duty expression abbreviation missing' do
         it 'returns duty expression description' do
           DutyExpressionFormatter.format(duty_expression_id: '12',
-                                         duty_expression_description: 'def').should == 'def'
+                                         duty_expression_description: 'def').should eq 'def'
         end
       end
     end


### PR DESCRIPTION
This translates | to non breaking spaces and still keeps these non breaking spaces
properly formatted.

This change is for https://www.pivotaltracker.com/story/show/46538537.

After deploy on EU002 footnote (https://www.gov.uk/trade-tariff/commodities/8108906020?country=&day=18&month=3&year=2013#import) and 06004 in https://www.gov.uk/trade-tariff/commodities/3907602000#import we should not be seeing html characters or wrong formatting.
