### PR TITLE
Quick accessibility fixes

### DIFF
--- a/app/views/measures/_measures.html.erb
+++ b/app/views/measures/_measures.html.erb
@@ -1,4 +1,4 @@
-<nav class="nav-tabs" role="navigation">
+<div class="nav-tabs">
   <ul>
     <li class='active'>
       <a href="#overview" data-toggle="tab">Overview</a>
@@ -13,7 +13,7 @@
       <a href="#footnotes" data-toggle="tab">Footnotes</a>
     </li>
   </ul>
-</nav>
+</div>
 
 <div id="measures-js" class='tab-content'>
   <article class='tab-pane active' id='overview'>


### PR DESCRIPTION
Feedback from an accessibility review showed misuse of the `nav` tag was making the document difficult to read:

https://www.pivotaltracker.com/story/show/47377249

Tabs do not need to be wrapped in `nav` tags as they are already identified by their role attribute.

Note: needs to be merged with the following pull requests:

https://github.com/alphagov/static/pull/238
https://github.com/alphagov/frontend/pull/328
https://github.com/alphagov/calendars/pull/31
