### PR TITLE
Bump Slimmer to 3.17.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ gem "httparty"
 gem "kaminari"
 
 gem "gds-api-adapters", "4.1.3"
-gem "plek", ">=1.0.0"
-gem "slimmer", "3.9.5"
+gem "plek", "1.3.1"
+gem "slimmer", "3.17.0"
 gem "addressable"
 
 gem "unicorn", "~> 4.3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,8 +148,7 @@ GEM
       net-ssh (>= 1.99.1)
     nokogiri (1.5.6)
     null_logger (0.0.1)
-    plek (1.0.0)
-      builder
+    plek (1.3.1)
     polyglot (0.3.3)
     pry (0.9.10)
       coderay (~> 1.0.5)
@@ -225,7 +224,7 @@ GEM
     simplecov-html (0.5.3)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (3.9.5)
+    slimmer (3.17.0)
       json
       lrucache (~> 0.1.3)
       nokogiri (~> 1.5.0)
@@ -286,7 +285,7 @@ DEPENDENCIES
   kaminari
   lograge (= 0.1.2)
   multi_json
-  plek (>= 1.0.0)
+  plek (= 1.3.1)
   pry-rails
   rails (= 3.2.13)
   router-client (~> 3.0.1)
@@ -295,7 +294,7 @@ DEPENDENCIES
   shoulda-matchers
   simplecov (~> 0.6.4)
   simplecov-rcov (~> 0.2.3)
-  slimmer (= 3.9.5)
+  slimmer (= 3.17.0)
   therubyracer
   uglifier (>= 1.0.3)
   unicorn (~> 4.3.1)


### PR DESCRIPTION
To allow us to fix the breadcrumb markup
