### PR TITLE
Bump toolkit to 0.32.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ end
 
 group :assets do
   gem "coffee-rails", "~> 3.2.1"
-  gem "govuk_frontend_toolkit", "0.15.0"
+  gem "govuk_frontend_toolkit", "0.32.2"
   gem "jquery-rails"
   gem "sass-rails", "~> 3.2.3"
   gem "therubyracer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
       lrucache (~> 0.1.1)
       null_logger
       plek
-    govuk_frontend_toolkit (0.15.0)
+    govuk_frontend_toolkit (0.32.2)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     haml (3.1.7)
@@ -270,7 +270,7 @@ DEPENDENCIES
   factory_girl_rails
   forgery
   gds-api-adapters (= 4.1.3)
-  govuk_frontend_toolkit (= 0.15.0)
+  govuk_frontend_toolkit (= 0.32.2)
   httparty
   jquery-rails
   kaminari


### PR DESCRIPTION
Continuation of this work: https://github.com/alphagov/static/pull/270

Associated with (though they don't need to be merged simultaneously):

https://github.com/alphagov/business-support-finder/pull/31
https://github.com/alphagov/calendars/pull/37
https://github.com/alphagov/design-principles/pull/47
https://github.com/alphagov/feedback/pull/53
https://github.com/alphagov/licence-finder/pull/36
https://github.com/alphagov/smart-answers/pull/466
https://github.com/alphagov/transaction-wrappers/pull/28
