### PR TITLE
Change API endpoint for latest Tariff updates

### DIFF
--- a/app/models/tariff_update.rb
+++ b/app/models/tariff_update.rb
@@ -3,7 +3,7 @@ require 'api_entity'
 class TariffUpdate
   include ApiEntity
 
-  collection_path "/updates"
+  collection_path "/updates/latest"
 
   attr_accessor :update_type, :state, :created_at, :updated_at, :filename
 

--- a/spec/vcr/sections_index.yml
+++ b/spec/vcr/sections_index.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://tariff-api.dev.gov.uk/updates
+    uri: http://tariff-api.dev.gov.uk/updates/latest
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/tariff_updates_index.yml
+++ b/spec/vcr/tariff_updates_index.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://tariff-api.dev.gov.uk/updates
+    uri: http://tariff-api.dev.gov.uk/updates/latest
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
Related to https://github.com/alphagov/trade-tariff-backend/pull/110

We are listing two latest applied updates in frontend's section listing page. With the change above the endpoint has changed so it has to change on the frontend as well.
