### PR TITLE
Add API request forwarder using HTTParty

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,11 @@
+require 'trade_tariff_frontend'
+
 TradeTariffFrontend::Application.routes.draw do
   scope :path => "#{APP_SLUG}" do
+    mount TradeTariffFrontend::RequestForwarder.new(
+      host: Rails.application.config.api_host
+    ), at: '/api'
+
     get "/" => "pages#index"
     get "healthcheck" => "healthcheck#check"
     match "/search" => "search#search", via: :get, as: :perform_search

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -1,0 +1,4 @@
+require 'trade_tariff_frontend/request_forwarder'
+
+module TradeTariffFrontend
+end

--- a/lib/trade_tariff_frontend/request_forwarder.rb
+++ b/lib/trade_tariff_frontend/request_forwarder.rb
@@ -1,0 +1,62 @@
+require 'uri'
+require 'net/http'
+
+module TradeTariffFrontend
+  class RequestForwarder
+    IGNORED_UPSTREAM_HEADERS = %w[status x-ua-compatible connection transfer-encoding]
+
+    def initialize(opts = {})
+      @host = URI.parse(opts.fetch(:host))
+    end
+
+    def host
+      @host.host
+    end
+
+    def port
+      @host.port
+    end
+
+    def call(env)
+      rackreq = Rack::Request.new(env)
+
+      case rackreq.request_method
+      # The API is read-only
+      when "GET", "HEAD"
+        response = HTTParty.send(rackreq.request_method.downcase, request_url_for(rackreq), request_headers_for(env))
+
+        Rack::Response.new(
+          [response.body],
+          response.code.to_i,
+          Rack::Utils::HeaderHash.new(
+            response.headers.
+                     except(*IGNORED_UPSTREAM_HEADERS).
+                     merge('X-Slimmer-Skip' => true)
+          )
+        ).finish
+      else
+        # "DELETE", "OPTIONS", "TRACE" "PUT", "POST"
+        #
+        # 405 METHOD NOT ALLOWED
+
+        Rack::Response.new([], 405, {})
+      end
+    end
+
+    private
+
+    def request_url_for(rackreq)
+      "http://#{host}:#{port}#{rackreq.env["PATH_INFO"]}"
+    end
+
+    def request_headers_for(env)
+      headers = Rack::Utils::HeaderHash.new
+
+      env.each { |key, value|
+        if key =~ /HTTP_(.*)/
+          headers[$1] = value
+        end
+      }
+    end
+  end
+end

--- a/spec/middleware/trade_tariff_frontend/request_forwarder_spec.rb
+++ b/spec/middleware/trade_tariff_frontend/request_forwarder_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+describe TradeTariffFrontend::RequestForwarder do
+  let(:app)          { ->(env) { [200, env, "app"] } }
+  let(:host)         { 'http://tariff-api.example.com' }
+  let(:request_path) { '/sections/1' }
+
+  let(:response_body) { "example" }
+
+  let :middleware do
+    described_class.new(host: host)
+  end
+
+  around do |example|
+    # These specs use WebMock
+    VCR.turned_off do
+      example.yield
+    end
+  end
+
+  it 'forwards response from upstream backend host for GETs' do
+    stub_request(:get, "#{host}#{request_path}").to_return(
+      status: 200,
+      body: response_body,
+      headers: { 'Content-Length' => response_body.size }
+    )
+
+    status, env, body = middleware.call env_for(request_path)
+
+    expect(body.body).to include response_body
+  end
+
+  it 'forwards response from upstream backend host for HEADs' do
+    stub_request(:head, "#{host}#{request_path}").to_return(
+      status: 200,
+      body: '',
+      headers: { 'Content-Length' => 0 }
+    )
+
+    status, env, body = middleware.call env_for(request_path, method: :head)
+
+    expect(status).to eq 200
+    expect(body.body).to eq [""]
+  end
+
+  it 'forwards response status code from upstream backend host' do
+    stub_request(:get, "#{host}#{request_path}").to_return(
+      status: 404,
+      body: 'Not Found',
+      headers: { 'Content-Length' => 'Not Found'.size }
+    )
+
+    status, env, body = middleware.call env_for(request_path)
+
+    expect(status).to eq 404
+  end
+
+  it 'forwards allowed headers from upstream backend host' do
+    stub_request(:get, "#{host}#{request_path}").to_return(
+      status: 200,
+      body: response_body,
+      headers: {
+        'Content-Length' => response_body.size,
+        'Content-Type' => 'text/html'
+      }
+    )
+
+    status, env, body = middleware.call env_for(request_path)
+
+    expect(env['Content-Type']).to eq 'text/html'
+  end
+
+  it 'does not forward non-allowed headers from upstream backend host' do
+    stub_request(:get, "#{host}#{request_path}").to_return(
+      status: 200,
+      body: response_body,
+      headers: {
+        'Content-Length' => response_body.size,
+        'X-UA-Compatible' => 'IE=9'
+      }
+    )
+
+    status, env, body = middleware.call env_for(request_path)
+
+    expect(env['X-UA-Compatible']).to be_blank
+  end
+
+  it 'only accepts GET requests' do
+    status, env, body = middleware.call env_for(request_path, method: :post)
+
+    expect(status).to eq 405 # METHOD NOT ALLOWED
+    expect(body).to be_blank
+  end
+
+  def env_for(url, opts = {})
+    Rack::MockRequest.env_for(url, opts)
+  end
+end


### PR DESCRIPTION
This change is for https://www.pivotaltracker.com/story/show/36718669

Plain Net::HTTP has weird issues in resolving tariff-api.dev.gov.uk in local VM. It works with localhost:3018 (tariff-api host), it does not work with full host name even though it is present in /etc/hosts. Just timeouts.

Works fine with HTTParty though and we have it as dependency already.

Currently only allowing GET and HEAD request, read-only.
