### PR TITLE
Do not double escape commodity descriptions

### DIFF
--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -14,7 +14,7 @@ module CommoditiesHelper
   def commodity_tree(main_commodity, commodities)
     if commodities.any?
       content_tag(:dl, class: 'commodities') do
-        content_tag(:dt, commodities.first.to_s) +
+        content_tag(:dt, commodities.first.to_s.html_safe) +
         content_tag(:dd, tree_node(main_commodity, commodities, commodities.first.number_indents))
       end
     else
@@ -37,7 +37,7 @@ module CommoditiesHelper
     if deeper_node.present?
       content_tag(:dd) do
         content_tag(:dl) do
-          content_tag(:dt, deeper_node) +
+          content_tag(:dt, deeper_node.to_s.html_safe) +
           tree_node(main_commodity, commodities, deeper_node.number_indents)
         end
       end
@@ -52,7 +52,7 @@ module CommoditiesHelper
                          title: "Full tariff code: #{commodity.code}",
                          class: 'identifier',
                          'aria-describedby' => "commodity-#{commodity.code}") +
-      content_tag(:span, "#{commodity.to_s} (#{link_to('changes', commodity_changes_path(commodity.declarable, format: :atom), class: 'feed')})".html_safe,
+      content_tag(:span, "#{commodity.to_s.html_safe} (#{link_to('changes', commodity_changes_path(commodity.declarable, format: :atom), class: 'feed')})".html_safe,
                          class: 'description',
                          id: "commodity-#{commodity.code}")
 

--- a/app/views/commodities/_commodity.html.erb
+++ b/app/views/commodities/_commodity.html.erb
@@ -1,12 +1,12 @@
 <% if commodity.has_children? %>
   <li class="has_children <%= commodity_level(commodity)%><%= leaf_position(commodity) %>">
-    <span class="description open" id="commodity-<%= commodity.short_code %>"><%= commodity %></span>
+    <span class="description open" id="commodity-<%= commodity.short_code %>"><%= commodity.to_s.html_safe %></span>
     <ul><%= render commodity.children %></ul>
   </li>
 <% else %>
   <li class="<%= commodity_level(commodity)%><%= leaf_position(commodity) %>">
     <a class="js-pjax" href="<%= commodity_path(commodity) %>" title="View complete information for this commodity">
-    <span class="description open" id="commodity-<%= commodity.short_code %>"><%= commodity %></span>
+    <span class="description open" id="commodity-<%= commodity.short_code %>"><%= commodity.to_s.html_safe %></span>
       <span class="identifier" aria-describedby="commodity-<%= commodity.short_code %>">
         <span class="chapter-code"><%= commodity.chapter_code %></span>
         <span class="heading-code"><%= commodity.heading_code %></span>

--- a/app/views/declarables/_declarable.html.erb
+++ b/app/views/declarables/_declarable.html.erb
@@ -12,7 +12,7 @@
               <dl>
                 <dt class="heading-code" title="Heading code"><%= declarable.heading_display_short_code %></dt>
                 <% if declarable.show_commodity_tree? %>
-                  <dd><%= link_to declarable.heading, heading_path(declarable.heading), class: "js-pjax" %>
+                  <dd><%= link_to declarable.heading.to_s.html_safe, heading_path(declarable.heading), class: "js-pjax" %>
                       <%= commodity_tree(declarable, declarable.ancestors) %>
                   </dd>
                 <% else %>


### PR DESCRIPTION
They get escaped by description formatter on the backend, there is no need to do that again on the frontend app

Noticed while working on #60242196 on Commodity 8501101010

Check 8501101010 on Preview for an example.
