### PR TITLE
Display validity periods with GoodsNomenclature changes

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -1,11 +1,11 @@
 require 'api_entity'
 require 'changeable'
 
-class Chapter
+class Chapter < GoodsNomenclature
   include ApiEntity
   include Models::Changeable
 
-  attr_accessor :description, :headings, :goods_nomenclature_item_id, :chapter_note, :formatted_description
+  attr_accessor :headings, :chapter_note
 
   has_one :section
   has_many :headings

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -2,7 +2,7 @@ require 'api_entity'
 require 'declarable'
 require 'changeable'
 
-class Commodity
+class Commodity < GoodsNomenclature
   include Models::Changeable
   include Models::Declarable
 

--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -1,0 +1,27 @@
+require 'api_entity'
+
+class GoodsNomenclature
+  include ApiEntity
+
+  attr_accessor :validity_start_date,
+                :validity_end_date,
+                :goods_nomenclature_item_id,
+                :formatted_description,
+                :description
+
+  def validity_start_date=(validity_start_date)
+    @attributes['validity_start_date'] = Date.parse(validity_start_date.to_s) if validity_start_date.present?
+  end
+
+  def validity_start_date
+    @attributes['validity_start_date'].presence || NullObject.new
+  end
+
+  def validity_end_date=(validity_end_date)
+    @attributes['validity_end_date'] = Date.parse(validity_end_date.to_s) if validity_end_date.present?
+  end
+
+  def validity_end_date
+    @attributes['validity_end_date'].presence || NullObject.new
+  end
+end

--- a/app/models/heading.rb
+++ b/app/models/heading.rb
@@ -2,7 +2,7 @@ require 'api_entity'
 require 'declarable'
 require 'changeable'
 
-class Heading
+class Heading < GoodsNomenclature
   include Models::Changeable
   include Models::Declarable
 

--- a/app/presenters/chapter_change_presenter.rb
+++ b/app/presenters/chapter_change_presenter.rb
@@ -1,10 +1,15 @@
-class ChapterChangePresenter < ChangePresenter
+class ChapterChangePresenter < GoodsNomenclatureChangePresenter
   def title
     "Chapter #{change_record.goods_nomenclature_item_id} ('#{change_record.description}') #{operation_name}"
   end
 
   def content
-    "Chapter #{change_record.goods_nomenclature_item_id} ('#{change_record.description}') #{operation_name}"
+    %Q{
+      Chapter #{change_record.goods_nomenclature_item_id} ('#{change_record.description}') #{operation_name}
+
+      #{effective_start_date}
+      #{effective_end_date}
+    }.strip
   end
 
   def anchor_link

--- a/app/presenters/goods_nomenclature_change_presenter.rb
+++ b/app/presenters/goods_nomenclature_change_presenter.rb
@@ -4,9 +4,32 @@ class GoodsNomenclatureChangePresenter < ChangePresenter
   end
 
   def content
-    "Commodity #{change_record.goods_nomenclature_item_id} ('#{change_record.description}') #{operation_name}"
+    %Q{
+      Commodity #{change_record.goods_nomenclature_item_id} ('#{change_record.description}') #{operation_name}"
+
+      #{effective_start_date}
+      #{effective_end_date}
+    }.strip
   end
 
   def anchor_link
+  end
+
+  def effective_start_date
+    "Effective start date: #{validity_start_date}"
+  end
+
+  def effective_end_date
+    "Effective end date: #{validity_end_date}" if validity_end_date.present?
+  end
+
+  private
+
+  def validity_start_date
+    change_record.validity_start_date.to_formatted_s(:default)
+  end
+
+  def validity_end_date
+    change_record.validity_end_date.to_formatted_s(:default)
   end
 end

--- a/app/presenters/heading_change_presenter.rb
+++ b/app/presenters/heading_change_presenter.rb
@@ -1,10 +1,15 @@
-class HeadingChangePresenter < ChangePresenter
+class HeadingChangePresenter < GoodsNomenclatureChangePresenter
   def title
     "Heading #{change_record.goods_nomenclature_item_id} ('#{change_record.description}') #{operation_name}"
   end
 
   def content
-    "Heading #{change_record.goods_nomenclature_item_id} ('#{change_record.description}') #{operation_name}"
+    %Q{
+      Heading #{change_record.goods_nomenclature_item_id} ('#{change_record.description}') #{operation_name}
+
+      #{effective_start_date}
+      #{effective_end_date}
+    }.strip
   end
 
   def anchor_link

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -4,6 +4,13 @@ FactoryGirl.define do
     position { 1 }
   end
 
+  factory :goods_nomenclature do
+    description { Forgery(:basic).text }
+    goods_nomenclature_item_id { "0100000000" }
+    validity_start_date { Date.today.ago(3.years) }
+    validity_end_date   { nil }
+  end
+
   factory :chapter do
     section
     description { Forgery(:basic).text }

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+describe GoodsNomenclature do
+  describe '#validity_start_date=' do
+    let(:goods_nomenclature) { described_class.new }
+
+    context 'passed date is present' do
+      it 'sets date' do
+        goods_nomenclature.validity_start_date = Date.today
+
+        expect(goods_nomenclature.validity_start_date).to eq Date.today.to_date
+      end
+    end
+
+    context 'passed date is blank' do
+      it 'does not set validity end date' do
+        goods_nomenclature.validity_start_date = nil
+
+        expect(goods_nomenclature.validity_start_date).to be_blank
+      end
+    end
+  end
+
+  describe '#validity_end_date=' do
+    let(:goods_nomenclature) { described_class.new }
+
+    context 'passed date is present' do
+      it 'sets date' do
+        goods_nomenclature.validity_end_date = Date.today
+
+        expect(goods_nomenclature.validity_end_date).to eq Date.today.to_date
+      end
+    end
+
+    context 'passed date is blank' do
+      it 'does not set validity end date' do
+        goods_nomenclature.validity_end_date = nil
+
+        expect(goods_nomenclature.validity_end_date).to be_blank
+      end
+    end
+  end
+
+  describe '#validity_start_date' do
+    context 'the date is set' do
+      let(:goods_nomenclature) {
+        build(:goods_nomenclature, validity_start_date: Date.today)
+      }
+
+      it 'returns instance of Date' do
+        expect(goods_nomenclature.validity_start_date).to be_kind_of Date
+      end
+
+      it 'returns parsed date' do
+        expect(goods_nomenclature.validity_start_date).to eq Date.today.to_date
+      end
+    end
+
+    context 'date is not set' do
+      let(:goods_nomenclature) {
+        build(:goods_nomenclature, validity_start_date: nil)
+      }
+
+      it 'returns NullObject' do
+        expect(goods_nomenclature.validity_start_date).to be_kind_of NullObject
+      end
+    end
+  end
+
+  describe '#validity_end_date' do
+    context 'the date is set' do
+      let(:goods_nomenclature) {
+        build(:goods_nomenclature, validity_end_date: Date.today)
+      }
+
+      it 'returns instance of Date' do
+        expect(goods_nomenclature.validity_end_date).to be_kind_of Date
+      end
+
+      it 'returns parsed date' do
+        expect(goods_nomenclature.validity_end_date).to eq Date.today.to_date
+      end
+    end
+
+    context 'date is not set' do
+      let(:goods_nomenclature) {
+        build(:goods_nomenclature, validity_end_date: nil)
+      }
+
+      it 'returns NullObject' do
+        expect(goods_nomenclature.validity_end_date).to be_kind_of NullObject
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change is for https://www.pivotaltracker.com/story/show/61287082

This is to avoid confusion on why users can see changes for one day, but cannot access commodity on Tariff at that day. Change messages now will include validity periods which should bring some clarity to this matter.

Requires merge on backend:
- https://github.com/alphagov/trade-tariff-backend/pull/129
