### PR TITLE
Display commodity synonym search results

### DIFF
--- a/app/assets/stylesheets/tariff.scss
+++ b/app/assets/stylesheets/tariff.scss
@@ -425,6 +425,10 @@ header.page-header div,
   background:#B6D7EB;
 }
 
+.commodity-code {
+  background:#B5DEDB;
+}
+
 article table {
     @include table;
     width:106.4%; /* override for static styles */
@@ -1421,6 +1425,18 @@ article.search-results {
         padding-left: 15%;
         margin-left: -15%;
       }
+    }
+  }
+
+  dl.result-commodities {
+    dt.commodity-code {
+      width: auto;
+      padding: 0 3px;
+    }
+
+    dl.commodities a {
+      padding-left: 14px;
+      margin-left: 14px;
     }
   }
 

--- a/app/models/search/reference_match.rb
+++ b/app/models/search/reference_match.rb
@@ -7,18 +7,18 @@ class Search
 
   class ReferenceMatch < BaseMatch
     BLANK_RESULT = OpenStruct.new(
-      sections: [], chapters: [], headings: []
+      sections: [], chapters: [], headings: [], commodities: []
     )
 
-    array_attr_reader :sections, :chapters, :headings
-    array_attr_writer :sections, :chapters, :headings
+    array_attr_reader :sections, :chapters, :headings, :commodities
+    array_attr_writer :sections, :chapters, :headings, :commodities
 
     def any?
-      [headings, chapters, sections].any? { |entity_group| entity_group.any? }
+      [headings, chapters, sections, commodities].any? { |entity_group| entity_group.any? }
     end
 
     def all
-      (sections + chapters + headings).flatten
+      (sections + chapters + headings + commodities).flatten
     end
 
     def size

--- a/app/views/search/_commodity.html.erb
+++ b/app/views/search/_commodity.html.erb
@@ -1,0 +1,4 @@
+<dt class="commodity-code" title="Commodity code"><%= commodity.display_short_code %></dt>
+<dd>
+  <%= link_to commodity.to_s.html_safe, commodity_path(commodity) %>
+</dd>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -17,15 +17,41 @@
 
     <% if @results.reference_match.headings.any? %>
       <h2>Most popular headings for <%= @search %>:</h2>
-      <dl class="results-subset">
+      <dl class="results-subset headings">
         <% @results.reference_match.headings.group_by(&:chapter_code).each do |chapter, headings| %>
-        <dt class="chapter-code" ttile="Chapter code"><%= headings.first.chapter.short_code %></dt>
+        <dt class="chapter-code" title="Chapter code"><%= headings.first.chapter.short_code %></dt>
         <dd>
           <%= link_to headings.first.chapter, chapter_path(headings.first.chapter) %>
           <dl class="results-headings">
             <%= render partial: 'search/heading', collection: headings.uniq.sort_by(&:short_code) %>
           </dl>
         </dd>
+        <% end %>
+      </dl>
+    <% end %>
+
+    <% if @results.reference_match.commodities.any? %>
+      <h2>Most popular commodities for <%= @search %>:</h2>
+      <dl class="results-subset result-commodities">
+        <% @results.reference_match.commodities.group_by(&:chapter_code).each do |chapter_code, chapter_commodities| %>
+          <dt class="chapter-code" title="Chapter code"><%= chapter_code %></dt>
+          <dd>
+            <%= link_to chapter_commodities.first.chapter.to_s.html_safe, chapter_path(chapter_commodities.first.chapter) %>
+
+            <dl class="headings">
+              <% chapter_commodities.group_by(&:heading_code).each do |heading_code, heading_commodities| %>
+                <dt class="heading-code" title="Heading code"><%= heading_code %></dt>
+
+                <dd>
+                  <%= link_to heading_commodities.first.heading, heading_path(heading_commodities.first.heading) %>
+
+                  <dl class="commodities">
+                    <%= render partial: 'search/commodity', collection: heading_commodities.uniq.sort_by(&:code) %>
+                  </dl>
+                </dd>
+              <% end %>
+            </dl>
+          </dd>
         <% end %>
       </dl>
     <% end %>


### PR DESCRIPTION
This change is for https://www.pivotaltracker.com/story/show/58810758

Adds synonyms on commodities display on the frontend. Been waiting to raise this PR until https://github.com/alphagov/trade-tariff-backend/pull/128 was merged in.

This depends on:
- https://github.com/alphagov/trade-tariff-backend/pull/136
- https://github.com/alphagov/trade-tariff-admin/pull/17
