### PR TITLE
Adjust A-Z listing style, show associated goods code

### DIFF
--- a/app/assets/stylesheets/tariff.scss
+++ b/app/assets/stylesheets/tariff.scss
@@ -1669,12 +1669,4 @@ article.a-z {
       }
     }
   }
-
-  ol.listing {
-    padding-left: 0;
-
-    li {
-      display: block;
-    }
-  }
 }

--- a/app/models/search_reference.rb
+++ b/app/models/search_reference.rb
@@ -5,7 +5,7 @@ class SearchReference
 
   collection_path '/search_references'
 
-  attr_accessor :id, :title, :referenced_class
+  attr_accessor :id, :title, :referenced_id, :referenced_class
 
   def referenced_entity
     reference_class.new(attributes['referenced'])

--- a/app/views/search_references/show.html.erb
+++ b/app/views/search_references/show.html.erb
@@ -4,14 +4,24 @@
       <%= a_z_index(letter) %>
     </ol>
 
-    <h1><%= letter.upcase %></h1>
+    <table>
+      <caption><%= letter.upcase %></caption>
 
-    <ol class="listing">
+      <tbody>
       <% @search_references.each do |search_reference| %>
-        <li>
-          <%= link_to search_reference, search_reference.link %>
-        </li>
+        <tr>
+          <td>
+            <%= link_to search_reference, search_reference.link %>
+          </td>
+          <td>
+            <%= search_reference.referenced_class %>
+          </td>
+          <td class="numerical">
+           <%= search_reference.referenced_id %>
+          </td>
+        </tr>
       <% end %>
-    </ol>
+      </tbody>
+    </table>
   </div>
 </article>


### PR DESCRIPTION
This change is for https://www.pivotaltracker.com/story/show/64159374

Changes synonym listing style so that they look like this:

![screen shot 2014-01-21 at 13 45 51](https://f.cloud.github.com/assets/13653/1962996/1a7982b8-8292-11e3-8ee0-2ceabefa7c46.png)

Shows associated Goods code.
