### PR TITLE
Rename measure footnote popup

### DIFF
--- a/app/views/measures/_measure_references.html.erb
+++ b/app/views/measures/_measure_references.html.erb
@@ -24,7 +24,7 @@
 <div class='footnotes' id='<%= footnote.id %>' data-popup='<%= footnote.id %>'>
   <article>
     <table>
-      <caption>Footnote for commodity:</caption>
+      <caption>Footnote for measure:</caption>
       <thead>
         <tr>
           <th>Code</th>


### PR DESCRIPTION
This change is for https://www.pivotaltracker.com/story/show/64828684.

Measures have associated footnotes. Commodity can also have associated footnotes. We do not display commodity footnotes in popups so "Footnote for commodity" is not an accurate popup title. Just renamed to "Footnotes for measure".
