### PR TITLE
Use dashes to separate heading words

### DIFF
--- a/app/views/declarables/_declarable.html.erb
+++ b/app/views/declarables/_declarable.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{declarable.description_plain} | Trade Tariff | GOV.UK" %>
+<% content_for :title, "#{declarable.description_plain} - Trade Tariff - GOV.UK" %>
 
 <article class="tariff commodity">
   <div class="inner">


### PR DESCRIPTION
Dashes are used everywhere else in this project and across GOV.UK declarable should follow that standard.
