### PR TITLE
Reduce crawler load

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,6 +1,8 @@
 require 'addressable/uri'
 
 class SearchController < ApplicationController
+  before_filter :bots_no_index_if_historical, only: :search
+
   def search
     @results = @search.perform
 
@@ -28,5 +30,11 @@ class SearchController < ApplicationController
 
       format.atom
     end
+  end
+
+  private
+
+  def bots_no_index_if_historical
+    response.headers["X-Robots-Tag"] = "none" unless @search.today?
   end
 end

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -10,6 +10,8 @@ class Search
                 :year,
                 :as_of    # legacy format for specifying date
 
+  delegate :today?, to: :date
+
   def perform
     response = self.class.post("/search", body: { t: t, as_of: date.to_s(:db) })
 

--- a/app/models/tariff_date.rb
+++ b/app/models/tariff_date.rb
@@ -6,7 +6,7 @@ class TariffDate
 
   attr_reader :date
 
-  delegate :day, :month, :year, :to_formatted_s, to: :date
+  delegate :day, :month, :year, :to_formatted_s, :today?, to: :date
 
   def self.parse(date_param)
     new(if valid_date_param?(date_param)

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -25,11 +25,11 @@
       <%= select_month(f.object.date, {}, { id: 'tariff_date_month', name: 'month' }) %>
       <%= f.label :year, 'Year', { class: 'visuallyhidden' }  %>
       <%= select_year(f.object.date, {end_year: 2008, start_year: (Date.today + 1.year).year }, { id: 'tariff_date_year', name: 'year' }) %>
-      <a class="submit" role='button' href='#set-date' title='set date'>set date</a>
+      <a class="submit" role='button' href='#set-date' title='set date' rel='nofollow'>set date</a>
     </span>
     <span class="text <%= @section_css %>">
       This tariff is for <%= @search.date.to_formatted_s(:long) %>
-      <a href='#change-date' title='change date'>change date</a>
+      <a href='#change-date' title='change date' rel='nofollow'>change date</a>
     </span>
   </fieldset>
 
@@ -42,7 +42,7 @@
     <span class='fields'>
       Trade between the UK and
       <%= f.select :country, f.object.countries.map{ |c| [c.description, c.id] }, { include_blank: 'All countries' }, name: 'country' %>
-      <a class="submit" role='button' href="#set-country" title='set country'>set country</a>
+      <a class="submit" role='button' href="#set-country" title='set country' rel='nofollow'>set country</a>
     </span>
     <span class='text'>
       <% if @search.filtered_by_country? %>
@@ -50,7 +50,7 @@
       <% else %>
         Trade between the UK and All countries
       <% end %>
-      <a href='#change-country' title='change country'>change country</a>
+      <a href='#change-country' title='change country' rel='nofollow'>change country</a>
     </span>
   </fieldset>
 <% end %>

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -192,4 +192,23 @@ describe SearchController, "GET to #search" do
       end
     end
   end
+
+  describe "header for crawlers", vcr: { cassette_name: "search#blank_match" } do
+    context "non historical" do
+      before { get :search }
+
+      it "should not include X-Robots-Tag" do
+        expect(response.headers["X-Robots-Tag"]).to_not be_present
+      end
+    end
+    context "historical" do
+      before {
+        get :search, {month: 1, year: 2008, day: 1}
+      }
+
+      it {
+        expect(response.headers["X-Robots-Tag"]).to eq("none")
+      }
+    end
+  end
 end


### PR DESCRIPTION
> Look to set appropriate entry in robots.txt to stop crawlers hammering the site.
> Since we allow searching back across time, we can let bots look at lots of content that is otherwise not used (and isn't in caches). This can be quite expensive.
- Add `rel='nofollow'` on the links that do the filtering
- Add `X-Robots-Tag` header on historical pages

[pivotal story](https://www.pivotaltracker.com/n/projects/488191/stories/68707106)
