### PR TITLE
do not show section duplicates when searching via synonyms

### DIFF
--- a/app/models/search/reference_match.rb
+++ b/app/models/search/reference_match.rb
@@ -24,9 +24,5 @@ class Search
     def size
       all.size
     end
-
-    def sections_uniq
-      sections.uniq { |s| s.to_param }
-    end
   end
 end

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -4,7 +4,7 @@
     <% if @results.reference_match.sections.any? %>
       <h2>Most popular sections for <%= @search %>:</h2>
       <dl class="results-subset sections">
-        <%= render partial: 'search/section', collection: @results.reference_match.sections_uniq %>
+        <%= render partial: 'search/section', collection: @results.reference_match.sections %>
       </dl>
     <% end %>
 

--- a/spec/vcr/search_duplicate_results.yml
+++ b/spec/vcr/search_duplicate_results.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://tariff-api.dev.gov.uk/search
     body:
       encoding: US-ASCII
-      string: t=synonym%201&as_of=2014-04-15
+      string: t=synonym%201&as_of=2014-04-18
     headers: {}
   response:
     status:
@@ -15,7 +15,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 15 Apr 2014 18:41:01 GMT
+      - Fri, 18 Apr 2014 14:33:12 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -24,179 +24,45 @@ http_interactions:
       - close
       Status:
       - 200 OK
-      X-Meta-Request-Version:
-      - 0.2.9
       X-Ua-Compatible:
       - IE=Edge
       Etag:
-      - ! '"4da3f9363613e79f9c513d11c62d719f"'
+      - ! '"74966852c7e44fae64e63c1ae971fb86"'
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 0aa4c73622e00dac003fef84f322fcff
+      - 78c0fb9a16b1df30ad471e01c0a77330
       X-Runtime:
-      - '1.722756'
+      - '3.243178'
       X-Frame-Options:
       - SAMEORIGIN
     body:
       encoding: US-ASCII
-      string: ! '{"type":"fuzzy_match","goods_nomenclature_match":{"chapters":[],"commodities":[{"_index":"tariff-commodities","_type":"commodity","_id":"33071","_score":1.0,"_source":{"id":33071,"goods_nomenclature_item_id":"1704905100","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Pastes,
-        including marzipan, in immediate packings of a net content of 1&nbsp;kg or
-        more","number_indents":3,"heading":{"goods_nomenclature_sid":33059,"goods_nomenclature_item_id":"1704000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Sugar
-        confectionery (including white chocolate), not containing cocoa","number_indents":0},"chapter":{"goods_nomenclature_sid":32980,"goods_nomenclature_item_id":"1700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Sugars
-        and sugar confectionery"},"section":{"numeral":"IV","title":"Prepared foodstuffs;
-        beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33144","_score":1.0,"_source":{"id":33144,"goods_nomenclature_item_id":"1806906010","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
-        immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33096,"goods_nomenclature_item_id":"1806000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Chocolate
-        and other food preparations containing cocoa","number_indents":0},"chapter":{"goods_nomenclature_sid":33088,"goods_nomenclature_item_id":"1800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Cocoa
-        and cocoa preparations"},"section":{"numeral":"IV","title":"Prepared foodstuffs;
-        beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33147","_score":1.0,"_source":{"id":33147,"goods_nomenclature_item_id":"1806907010","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
-        immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33096,"goods_nomenclature_item_id":"1806000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Chocolate
-        and other food preparations containing cocoa","number_indents":0},"chapter":{"goods_nomenclature_sid":33088,"goods_nomenclature_item_id":"1800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Cocoa
-        and cocoa preparations"},"section":{"numeral":"IV","title":"Prepared foodstuffs;
-        beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33151","_score":1.0,"_source":{"id":33151,"goods_nomenclature_item_id":"1806909011","producline_suffix":"10","validity_start_date":"1992-03-01T00:00:00+00:00","validity_end_date":null,"description":"In
-        immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33096,"goods_nomenclature_item_id":"1806000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Chocolate
-        and other food preparations containing cocoa","number_indents":0},"chapter":{"goods_nomenclature_sid":33088,"goods_nomenclature_item_id":"1800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Cocoa
-        and cocoa preparations"},"section":{"numeral":"IV","title":"Prepared foodstuffs;
-        beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33900","_score":1.0,"_source":{"id":33900,"goods_nomenclature_item_id":"2008501100","producline_suffix":"20","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
-        immediate packings of a net content exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
-        nuts and other edible parts of plants, otherwise prepared or preserved, whether
-        or not containing added sugar or other sweetening matter or spirit, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
-        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
-        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33907","_score":1.0,"_source":{"id":33907,"goods_nomenclature_item_id":"2008505100","producline_suffix":"10","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
-        immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
-        nuts and other edible parts of plants, otherwise prepared or preserved, whether
-        or not containing added sugar or other sweetening matter or spirit, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
-        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
-        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33911","_score":1.0,"_source":{"id":33911,"goods_nomenclature_item_id":"2008506100","producline_suffix":"20","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
-        added sugar, in immediate packings of a net content exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
-        nuts and other edible parts of plants, otherwise prepared or preserved, whether
-        or not containing added sugar or other sweetening matter or spirit, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
-        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
-        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33914","_score":1.0,"_source":{"id":33914,"goods_nomenclature_item_id":"2008507100","producline_suffix":"10","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
-        added sugar, in immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
-        nuts and other edible parts of plants, otherwise prepared or preserved, whether
-        or not containing added sugar or other sweetening matter or spirit, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
-        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
-        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"80849","_score":1.0,"_source":{"id":80849,"goods_nomenclature_item_id":"2008605000","producline_suffix":"80","validity_start_date":"2005-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
-        added sugar, in immediate packings of a net content exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
-        nuts and other edible parts of plants, otherwise prepared or preserved, whether
-        or not containing added sugar or other sweetening matter or spirit, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
-        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
-        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"80852","_score":1.0,"_source":{"id":80852,"goods_nomenclature_item_id":"2008606000","producline_suffix":"80","validity_start_date":"2005-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
-        added sugar, in immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
-        nuts and other edible parts of plants, otherwise prepared or preserved, whether
-        or not containing added sugar or other sweetening matter or spirit, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
-        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
-        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33958","_score":1.0,"_source":{"id":33958,"goods_nomenclature_item_id":"2008701100","producline_suffix":"20","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
-        immediate packings of a net content exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
-        nuts and other edible parts of plants, otherwise prepared or preserved, whether
-        or not containing added sugar or other sweetening matter or spirit, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
-        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
-        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33965","_score":1.0,"_source":{"id":33965,"goods_nomenclature_item_id":"2008705100","producline_suffix":"10","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
-        immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
-        nuts and other edible parts of plants, otherwise prepared or preserved, whether
-        or not containing added sugar or other sweetening matter or spirit, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
-        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
-        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33969","_score":1.0,"_source":{"id":33969,"goods_nomenclature_item_id":"2008706100","producline_suffix":"20","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
-        added sugar, in immediate packings of a net content exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
-        nuts and other edible parts of plants, otherwise prepared or preserved, whether
-        or not containing added sugar or other sweetening matter or spirit, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
-        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
-        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33972","_score":1.0,"_source":{"id":33972,"goods_nomenclature_item_id":"2008707100","producline_suffix":"10","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
-        added sugar, in immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
-        nuts and other edible parts of plants, otherwise prepared or preserved, whether
-        or not containing added sugar or other sweetening matter or spirit, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
-        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
-        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33991","_score":1.0,"_source":{"id":33991,"goods_nomenclature_item_id":"2008805000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
-        added sugar, in immediate packings of a net content exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
-        nuts and other edible parts of plants, otherwise prepared or preserved, whether
-        or not containing added sugar or other sweetening matter or spirit, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
-        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
-        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33992","_score":1.0,"_source":{"id":33992,"goods_nomenclature_item_id":"2008807000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
-        added sugar, in immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
-        nuts and other edible parts of plants, otherwise prepared or preserved, whether
-        or not containing added sugar or other sweetening matter or spirit, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
-        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
-        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"94874","_score":1.0,"_source":{"id":94874,"goods_nomenclature_item_id":"2008939100","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
-        added sugar, in immediate packings of a net content exceeding 1&nbsp;kg","number_indents":4,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
-        nuts and other edible parts of plants, otherwise prepared or preserved, whether
-        or not containing added sugar or other sweetening matter or spirit, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
-        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
-        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"94878","_score":1.0,"_source":{"id":94878,"goods_nomenclature_item_id":"2008939300","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
-        added sugar, in immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":4,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
-        nuts and other edible parts of plants, otherwise prepared or preserved, whether
-        or not containing added sugar or other sweetening matter or spirit, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
-        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
-        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"98037","_score":1.0,"_source":{"id":98037,"goods_nomenclature_item_id":"2008970300","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
-        immediate packings of a net content exceeding 1&nbsp;kg","number_indents":4,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
-        nuts and other edible parts of plants, otherwise prepared or preserved, whether
-        or not containing added sugar or other sweetening matter or spirit, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
-        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
-        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"98038","_score":1.0,"_source":{"id":98038,"goods_nomenclature_item_id":"2008970500","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
-        immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":4,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
-        nuts and other edible parts of plants, otherwise prepared or preserved, whether
-        or not containing added sugar or other sweetening matter or spirit, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
-        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
-        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"94903","_score":1.0,"_source":{"id":94903,"goods_nomenclature_item_id":"2008975100","producline_suffix":"30","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
-        immediate packings of a net content exceeding 1&nbsp;kg","number_indents":5,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
-        nuts and other edible parts of plants, otherwise prepared or preserved, whether
-        or not containing added sugar or other sweetening matter or spirit, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
-        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
-        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"34082","_score":1.0,"_source":{"id":34082,"goods_nomenclature_item_id":"2008994100","producline_suffix":"20","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
-        added sugar, in immediate packings of a net content exceeding 1&nbsp;kg","number_indents":4,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
-        nuts and other edible parts of plants, otherwise prepared or preserved, whether
-        or not containing added sugar or other sweetening matter or spirit, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
-        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
-        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"34110","_score":1.0,"_source":{"id":34110,"goods_nomenclature_item_id":"2008995100","producline_suffix":"10","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
-        added sugar, in immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":4,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
-        nuts and other edible parts of plants, otherwise prepared or preserved, whether
-        or not containing added sugar or other sweetening matter or spirit, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
-        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
-        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"34515","_score":1.0,"_source":{"id":34515,"goods_nomenclature_item_id":"2102201100","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
-        tablet, cube or similar form, or in immediate packings of a net content not
-        exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":34502,"goods_nomenclature_item_id":"2102000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Yeasts
-        (active or inactive); other single-cell micro-organisms, dead (but not including
-        vaccines of heading&nbsp;3002); prepared baking powders","number_indents":0},"chapter":{"goods_nomenclature_sid":34458,"goods_nomenclature_item_id":"2100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        edible preparations"},"section":{"numeral":"IV","title":"Prepared foodstuffs;
-        beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"32381","_score":1.0,"_source":{"id":32381,"goods_nomenclature_item_id":"1504201010","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
+      string: ! '{"type":"fuzzy_match","goods_nomenclature_match":{"chapters":[],"commodities":[{"_index":"tariff-commodities","_type":"commodity","_id":"88304","_score":1.0,"_source":{"id":88304,"goods_nomenclature_item_id":"0602909110","producline_suffix":"80","validity_start_date":"2007-03-01T00:00:00+00:00","validity_end_date":null,"description":"Potted
+        plants not exceeding 1&nbsp;m in height","number_indents":6,"heading":{"goods_nomenclature_sid":30069,"goods_nomenclature_item_id":"0602000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        live plants (including their roots), cuttings and slips; mushroom spawn","number_indents":0},"chapter":{"goods_nomenclature_sid":30055,"goods_nomenclature_item_id":"0600000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Live
+        trees and other plants; bulbs, roots and the like; cut flowers and ornamental
+        foliage"},"section":{"numeral":"II","title":"Vegetable products","position":2}}},{"_index":"tariff-commodities","_type":"commodity","_id":"88307","_score":1.0,"_source":{"id":88307,"goods_nomenclature_item_id":"0602909910","producline_suffix":"80","validity_start_date":"2007-03-01T00:00:00+00:00","validity_end_date":null,"description":"Potted
+        plants not exceeding 1&nbsp;m in height","number_indents":6,"heading":{"goods_nomenclature_sid":30069,"goods_nomenclature_item_id":"0602000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        live plants (including their roots), cuttings and slips; mushroom spawn","number_indents":0},"chapter":{"goods_nomenclature_sid":30055,"goods_nomenclature_item_id":"0600000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Live
+        trees and other plants; bulbs, roots and the like; cut flowers and ornamental
+        foliage"},"section":{"numeral":"II","title":"Vegetable products","position":2}}},{"_index":"tariff-commodities","_type":"commodity","_id":"70919","_score":1.0,"_source":{"id":70919,"goods_nomenclature_item_id":"0701905000","producline_suffix":"80","validity_start_date":"2000-01-01T00:00:00+00:00","validity_end_date":null,"description":"New,
+        from 1&nbsp;January to 30&nbsp;June","number_indents":3,"heading":{"goods_nomenclature_sid":30241,"goods_nomenclature_item_id":"0701000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Potatoes,
+        fresh or chilled","number_indents":0},"chapter":{"goods_nomenclature_sid":30240,"goods_nomenclature_item_id":"0700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Edible
+        vegetables and certain roots and tubers"},"section":{"numeral":"II","title":"Vegetable
+        products","position":2}}},{"_index":"tariff-commodities","_type":"commodity","_id":"76064","_score":1.0,"_source":{"id":76064,"goods_nomenclature_item_id":"0302112000","producline_suffix":"80","validity_start_date":"2003-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        the species Oncorhynchus mykiss, with heads and gills on, gutted, weighing
+        more than 1,2&nbsp;kg each, or with heads off, gilled and gutted, weighing
+        more than 1&nbsp;kg each","number_indents":3,"heading":{"goods_nomenclature_sid":28402,"goods_nomenclature_item_id":"0302000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fish,
+        fresh or chilled, excluding fish fillets and other fish meat of heading&nbsp;0304","number_indents":0},"chapter":{"goods_nomenclature_sid":28373,"goods_nomenclature_item_id":"0300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Fish
+        and crustaceans, molluscs and other aquatic invertebrates"},"section":{"numeral":"I","title":"Live
+        animals; animal products","position":1}}},{"_index":"tariff-commodities","_type":"commodity","_id":"94028","_score":1.0,"_source":{"id":94028,"goods_nomenclature_item_id":"0303142000","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        the species Oncorhynchus mykiss, with heads and gills on, gutted, weighing
+        more than 1,2&nbsp;kg each, or with heads off, gilled and gutted, weighing
+        more than 1&nbsp;kg each","number_indents":3,"heading":{"goods_nomenclature_sid":28590,"goods_nomenclature_item_id":"0303000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fish,
+        frozen, excluding fish fillets and other fish meat of heading&nbsp;0304","number_indents":0},"chapter":{"goods_nomenclature_sid":28373,"goods_nomenclature_item_id":"0300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Fish
+        and crustaceans, molluscs and other aquatic invertebrates"},"section":{"numeral":"I","title":"Live
+        animals; animal products","position":1}}},{"_index":"tariff-commodities","_type":"commodity","_id":"32381","_score":1.0,"_source":{"id":32381,"goods_nomenclature_item_id":"1504201010","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
         immediate packings of a net capacity of 1&nbsp;kg or less","number_indents":3,"heading":{"goods_nomenclature_sid":32373,"goods_nomenclature_item_id":"1504000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fats
         and oils and their fractions, of fish or marine mammals, whether or not refined,
         but not chemically modified","number_indents":0},"chapter":{"goods_nomenclature_sid":32355,"goods_nomenclature_item_id":"1500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Animal
@@ -561,43 +427,65 @@ http_interactions:
         specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
         of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
         foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"55656","_score":1.0,"_source":{"id":55656,"goods_nomenclature_item_id":"2204309200","producline_suffix":"20","validity_start_date":"1995-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a density of 1,33&nbsp;g/cm<sup>3</sup>&nbsp;or less at 20&nbsp;\u00b0C and
-        of an actual alcoholic strength by volume not exceeding 1%&nbsp;vol","number_indents":3,"heading":{"goods_nomenclature_sid":34654,"goods_nomenclature_item_id":"2204000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Wine
-        of fresh grapes, including fortified wines; grape must other than that of
-        heading No  2009","number_indents":0},"chapter":{"goods_nomenclature_sid":34628,"goods_nomenclature_item_id":"2200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Beverages,
-        spirits and vinegar"},"section":{"numeral":"IV","title":"Prepared foodstuffs;
-        beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95151","_score":1.0,"_source":{"id":95151,"goods_nomenclature_item_id":"2403110000","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"Water-pipe
-        tobacco specified in subheading note 1 to this chapter","number_indents":2,"heading":{"goods_nomenclature_sid":35287,"goods_nomenclature_item_id":"2403000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        manufactured tobacco and manufactured tobacco substitutes; ''homogenised''
-        or ''reconstituted'' tobacco; tobacco extracts and essences","number_indents":0},"chapter":{"goods_nomenclature_sid":35246,"goods_nomenclature_item_id":"2400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Tobacco
-        and manufactured tobacco substitutes"},"section":{"numeral":"IV","title":"Prepared
-        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92836","_score":1.0,"_source":{"id":92836,"goods_nomenclature_item_id":"2106108030","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
-        more than 1% milk fats, 1% other fats or more than 5% sugars","number_indents":3,"heading":{"goods_nomenclature_sid":34567,"goods_nomenclature_item_id":"2106000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Food
-        preparations not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":34458,"goods_nomenclature_item_id":"2100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        edible preparations"},"section":{"numeral":"IV","title":"Prepared foodstuffs;
-        beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92846","_score":1.0,"_source":{"id":92846,"goods_nomenclature_item_id":"2106909826","producline_suffix":"20","validity_start_date":"2010-06-01T00:00:00+00:00","validity_end_date":null,"description":"In
-        immediate packings of a net capacity of 1&nbsp;kg or less","number_indents":5,"heading":{"goods_nomenclature_sid":34567,"goods_nomenclature_item_id":"2106000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Food
-        preparations not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":34458,"goods_nomenclature_item_id":"2100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        edible preparations"},"section":{"numeral":"IV","title":"Prepared foodstuffs;
-        beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91914","_score":1.0,"_source":{"id":91914,"goods_nomenclature_item_id":"2204210600","producline_suffix":"10","validity_start_date":"2010-01-01T00:00:00+00:00","validity_end_date":null,"description":"Wine,
-        other than that referred to in subheading 2204&nbsp;10, in bottles with ''mushroom''
-        stoppers held in place by ties or fastenings; wine, otherwise put up, with
-        an excess pressure due to carbon dioxide in solution of not less than 1&nbsp;bar
-        but less than 3&nbsp;bar, measured at a temperature of 20&nbsp;\u00b0C","number_indents":3,"heading":{"goods_nomenclature_sid":34654,"goods_nomenclature_item_id":"2204000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Wine
-        of fresh grapes, including fortified wines; grape must other than that of
-        heading No  2009","number_indents":0},"chapter":{"goods_nomenclature_sid":34628,"goods_nomenclature_item_id":"2200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Beverages,
-        spirits and vinegar"},"section":{"numeral":"IV","title":"Prepared foodstuffs;
-        beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"34813","_score":1.0,"_source":{"id":34813,"goods_nomenclature_item_id":"2204291000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Wine,
-        other than that referred to in subheading 2204&nbsp;10, in bottles with ''mushroom''
-        stoppers held in place by ties or fastenings; wine, otherwise put up, with
-        an excess pressure due to carbon dioxide in solution of not less than 1&nbsp;bar
-        but less than 3&nbsp;bar, measured at a temperature of 20&nbsp;\u00b0C","number_indents":3,"heading":{"goods_nomenclature_sid":34654,"goods_nomenclature_item_id":"2204000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Wine
-        of fresh grapes, including fortified wines; grape must other than that of
-        heading No  2009","number_indents":0},"chapter":{"goods_nomenclature_sid":34628,"goods_nomenclature_item_id":"2200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Beverages,
-        spirits and vinegar"},"section":{"numeral":"IV","title":"Prepared foodstuffs;
-        beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"31786","_score":1.0,"_source":{"id":31786,"goods_nomenclature_item_id":"0910910000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Mixtures
+        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33071","_score":1.0,"_source":{"id":33071,"goods_nomenclature_item_id":"1704905100","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Pastes,
+        including marzipan, in immediate packings of a net content of 1&nbsp;kg or
+        more","number_indents":3,"heading":{"goods_nomenclature_sid":33059,"goods_nomenclature_item_id":"1704000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Sugar
+        confectionery (including white chocolate), not containing cocoa","number_indents":0},"chapter":{"goods_nomenclature_sid":32980,"goods_nomenclature_item_id":"1700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Sugars
+        and sugar confectionery"},"section":{"numeral":"IV","title":"Prepared foodstuffs;
+        beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33144","_score":1.0,"_source":{"id":33144,"goods_nomenclature_item_id":"1806906010","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
+        immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33096,"goods_nomenclature_item_id":"1806000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Chocolate
+        and other food preparations containing cocoa","number_indents":0},"chapter":{"goods_nomenclature_sid":33088,"goods_nomenclature_item_id":"1800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Cocoa
+        and cocoa preparations"},"section":{"numeral":"IV","title":"Prepared foodstuffs;
+        beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33147","_score":1.0,"_source":{"id":33147,"goods_nomenclature_item_id":"1806907010","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
+        immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33096,"goods_nomenclature_item_id":"1806000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Chocolate
+        and other food preparations containing cocoa","number_indents":0},"chapter":{"goods_nomenclature_sid":33088,"goods_nomenclature_item_id":"1800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Cocoa
+        and cocoa preparations"},"section":{"numeral":"IV","title":"Prepared foodstuffs;
+        beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33151","_score":1.0,"_source":{"id":33151,"goods_nomenclature_item_id":"1806909011","producline_suffix":"10","validity_start_date":"1992-03-01T00:00:00+00:00","validity_end_date":null,"description":"In
+        immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33096,"goods_nomenclature_item_id":"1806000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Chocolate
+        and other food preparations containing cocoa","number_indents":0},"chapter":{"goods_nomenclature_sid":33088,"goods_nomenclature_item_id":"1800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Cocoa
+        and cocoa preparations"},"section":{"numeral":"IV","title":"Prepared foodstuffs;
+        beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"29419","_score":1.0,"_source":{"id":29419,"goods_nomenclature_item_id":"0401100000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a fat content, by weight, not exceeding 1%","number_indents":1,"heading":{"goods_nomenclature_sid":29418,"goods_nomenclature_item_id":"0401000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Milk
+        and cream, not concentrated nor containing added sugar or other sweetening
+        matter","number_indents":0},"chapter":{"goods_nomenclature_sid":29417,"goods_nomenclature_item_id":"0400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Dairy
+        produce; birds''eggs; natural honey; edible products of animal origin, not
+        elsewhere specified or included"},"section":{"numeral":"I","title":"Live animals;
+        animal products","position":1}}},{"_index":"tariff-commodities","_type":"commodity","_id":"29422","_score":1.0,"_source":{"id":29422,"goods_nomenclature_item_id":"0401200000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a fat content, by weight, exceeding 1% but not exceeding 6%","number_indents":1,"heading":{"goods_nomenclature_sid":29418,"goods_nomenclature_item_id":"0401000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Milk
+        and cream, not concentrated nor containing added sugar or other sweetening
+        matter","number_indents":0},"chapter":{"goods_nomenclature_sid":29417,"goods_nomenclature_item_id":"0400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Dairy
+        produce; birds''eggs; natural honey; edible products of animal origin, not
+        elsewhere specified or included"},"section":{"numeral":"I","title":"Live animals;
+        animal products","position":1}}},{"_index":"tariff-commodities","_type":"commodity","_id":"59400","_score":1.0,"_source":{"id":59400,"goods_nomenclature_item_id":"0405101100","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
+        immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":4,"heading":{"goods_nomenclature_sid":29713,"goods_nomenclature_item_id":"0405000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Butter
+        and other fats and oils derived from milk","number_indents":0},"chapter":{"goods_nomenclature_sid":29417,"goods_nomenclature_item_id":"0400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Dairy
+        produce; birds''eggs; natural honey; edible products of animal origin, not
+        elsewhere specified or included"},"section":{"numeral":"I","title":"Live animals;
+        animal products","position":1}}},{"_index":"tariff-commodities","_type":"commodity","_id":"63362","_score":1.0,"_source":{"id":63362,"goods_nomenclature_item_id":"0405201010","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
+        immediate packings of a net capacity of 1&nbsp;kg or less","number_indents":3,"heading":{"goods_nomenclature_sid":29713,"goods_nomenclature_item_id":"0405000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Butter
+        and other fats and oils derived from milk","number_indents":0},"chapter":{"goods_nomenclature_sid":29417,"goods_nomenclature_item_id":"0400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Dairy
+        produce; birds''eggs; natural honey; edible products of animal origin, not
+        elsewhere specified or included"},"section":{"numeral":"I","title":"Live animals;
+        animal products","position":1}}},{"_index":"tariff-commodities","_type":"commodity","_id":"63364","_score":1.0,"_source":{"id":63364,"goods_nomenclature_item_id":"0405203010","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
+        immediate packings of a net capacity of 1&nbsp;kg or less","number_indents":3,"heading":{"goods_nomenclature_sid":29713,"goods_nomenclature_item_id":"0405000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Butter
+        and other fats and oils derived from milk","number_indents":0},"chapter":{"goods_nomenclature_sid":29417,"goods_nomenclature_item_id":"0400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Dairy
+        produce; birds''eggs; natural honey; edible products of animal origin, not
+        elsewhere specified or included"},"section":{"numeral":"I","title":"Live animals;
+        animal products","position":1}}},{"_index":"tariff-commodities","_type":"commodity","_id":"59111","_score":1.0,"_source":{"id":59111,"goods_nomenclature_item_id":"0406102010","producline_suffix":"80","validity_start_date":"1995-07-01T00:00:00+00:00","validity_end_date":null,"description":"Pizza
+        cheese, frozen, cut into pieces each weighing not more than 1&nbsp;g, in containers
+        of 5&nbsp;kg or more, of a water content, by weight, of 52% and a fat content,
+        by weight, of 38% or more","number_indents":3,"heading":{"goods_nomenclature_sid":29719,"goods_nomenclature_item_id":"0406000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Cheese
+        and curd","number_indents":0},"chapter":{"goods_nomenclature_sid":29417,"goods_nomenclature_item_id":"0400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Dairy
+        produce; birds''eggs; natural honey; edible products of animal origin, not
+        elsewhere specified or included"},"section":{"numeral":"I","title":"Live animals;
+        animal products","position":1}}},{"_index":"tariff-commodities","_type":"commodity","_id":"59112","_score":1.0,"_source":{"id":59112,"goods_nomenclature_item_id":"0406108010","producline_suffix":"80","validity_start_date":"1995-07-01T00:00:00+00:00","validity_end_date":null,"description":"Pizza
+        cheese, frozen, cut into pieces each weighing not more than 1&nbsp;g, in containers
+        of 5&nbsp;kg or more, of a water content, by weight, of 52% and a fat content,
+        by weight, of 38% or more","number_indents":3,"heading":{"goods_nomenclature_sid":29719,"goods_nomenclature_item_id":"0406000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Cheese
+        and curd","number_indents":0},"chapter":{"goods_nomenclature_sid":29417,"goods_nomenclature_item_id":"0400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Dairy
+        produce; birds''eggs; natural honey; edible products of animal origin, not
+        elsewhere specified or included"},"section":{"numeral":"I","title":"Live animals;
+        animal products","position":1}}},{"_index":"tariff-commodities","_type":"commodity","_id":"31786","_score":1.0,"_source":{"id":31786,"goods_nomenclature_item_id":"0910910000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Mixtures
         referred to in note&nbsp;1(b) to this chapter","number_indents":2,"heading":{"goods_nomenclature_sid":31771,"goods_nomenclature_item_id":"0910000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Ginger,
         saffron, turmeric (curcuma), thyme, bay leaves, curry and other spices","number_indents":0},"chapter":{"goods_nomenclature_sid":31699,"goods_nomenclature_item_id":"0900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Coffee,
         tea, mat\u00e9 and spices"},"section":{"numeral":"II","title":"Vegetable products","position":2}}},{"_index":"tariff-commodities","_type":"commodity","_id":"94644","_score":1.0,"_source":{"id":94644,"goods_nomenclature_item_id":"1003900020","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"with
@@ -646,254 +534,516 @@ http_interactions:
         pears, in bulk, from 1&nbsp;August to 31&nbsp;December","number_indents":2,"heading":{"goods_nomenclature_sid":31254,"goods_nomenclature_item_id":"0808000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Apples,
         pears and quinces, fresh","number_indents":0},"chapter":{"goods_nomenclature_sid":30808,"goods_nomenclature_item_id":"0800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Edible
         fruit and nuts; peel of citrus fruit or melons"},"section":{"numeral":"II","title":"Vegetable
-        products","position":2}}},{"_index":"tariff-commodities","_type":"commodity","_id":"29419","_score":1.0,"_source":{"id":29419,"goods_nomenclature_item_id":"0401100000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a fat content, by weight, not exceeding 1%","number_indents":1,"heading":{"goods_nomenclature_sid":29418,"goods_nomenclature_item_id":"0401000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Milk
-        and cream, not concentrated nor containing added sugar or other sweetening
-        matter","number_indents":0},"chapter":{"goods_nomenclature_sid":29417,"goods_nomenclature_item_id":"0400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Dairy
-        produce; birds''eggs; natural honey; edible products of animal origin, not
-        elsewhere specified or included"},"section":{"numeral":"I","title":"Live animals;
-        animal products","position":1}}},{"_index":"tariff-commodities","_type":"commodity","_id":"29422","_score":1.0,"_source":{"id":29422,"goods_nomenclature_item_id":"0401200000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a fat content, by weight, exceeding 1% but not exceeding 6%","number_indents":1,"heading":{"goods_nomenclature_sid":29418,"goods_nomenclature_item_id":"0401000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Milk
-        and cream, not concentrated nor containing added sugar or other sweetening
-        matter","number_indents":0},"chapter":{"goods_nomenclature_sid":29417,"goods_nomenclature_item_id":"0400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Dairy
-        produce; birds''eggs; natural honey; edible products of animal origin, not
-        elsewhere specified or included"},"section":{"numeral":"I","title":"Live animals;
-        animal products","position":1}}},{"_index":"tariff-commodities","_type":"commodity","_id":"59400","_score":1.0,"_source":{"id":59400,"goods_nomenclature_item_id":"0405101100","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
-        immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":4,"heading":{"goods_nomenclature_sid":29713,"goods_nomenclature_item_id":"0405000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Butter
-        and other fats and oils derived from milk","number_indents":0},"chapter":{"goods_nomenclature_sid":29417,"goods_nomenclature_item_id":"0400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Dairy
-        produce; birds''eggs; natural honey; edible products of animal origin, not
-        elsewhere specified or included"},"section":{"numeral":"I","title":"Live animals;
-        animal products","position":1}}},{"_index":"tariff-commodities","_type":"commodity","_id":"63362","_score":1.0,"_source":{"id":63362,"goods_nomenclature_item_id":"0405201010","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
-        immediate packings of a net capacity of 1&nbsp;kg or less","number_indents":3,"heading":{"goods_nomenclature_sid":29713,"goods_nomenclature_item_id":"0405000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Butter
-        and other fats and oils derived from milk","number_indents":0},"chapter":{"goods_nomenclature_sid":29417,"goods_nomenclature_item_id":"0400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Dairy
-        produce; birds''eggs; natural honey; edible products of animal origin, not
-        elsewhere specified or included"},"section":{"numeral":"I","title":"Live animals;
-        animal products","position":1}}},{"_index":"tariff-commodities","_type":"commodity","_id":"63364","_score":1.0,"_source":{"id":63364,"goods_nomenclature_item_id":"0405203010","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
-        immediate packings of a net capacity of 1&nbsp;kg or less","number_indents":3,"heading":{"goods_nomenclature_sid":29713,"goods_nomenclature_item_id":"0405000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Butter
-        and other fats and oils derived from milk","number_indents":0},"chapter":{"goods_nomenclature_sid":29417,"goods_nomenclature_item_id":"0400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Dairy
-        produce; birds''eggs; natural honey; edible products of animal origin, not
-        elsewhere specified or included"},"section":{"numeral":"I","title":"Live animals;
-        animal products","position":1}}},{"_index":"tariff-commodities","_type":"commodity","_id":"59111","_score":1.0,"_source":{"id":59111,"goods_nomenclature_item_id":"0406102010","producline_suffix":"80","validity_start_date":"1995-07-01T00:00:00+00:00","validity_end_date":null,"description":"Pizza
-        cheese, frozen, cut into pieces each weighing not more than 1&nbsp;g, in containers
-        of 5&nbsp;kg or more, of a water content, by weight, of 52% and a fat content,
-        by weight, of 38% or more","number_indents":3,"heading":{"goods_nomenclature_sid":29719,"goods_nomenclature_item_id":"0406000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Cheese
-        and curd","number_indents":0},"chapter":{"goods_nomenclature_sid":29417,"goods_nomenclature_item_id":"0400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Dairy
-        produce; birds''eggs; natural honey; edible products of animal origin, not
-        elsewhere specified or included"},"section":{"numeral":"I","title":"Live animals;
-        animal products","position":1}}},{"_index":"tariff-commodities","_type":"commodity","_id":"59112","_score":1.0,"_source":{"id":59112,"goods_nomenclature_item_id":"0406108010","producline_suffix":"80","validity_start_date":"1995-07-01T00:00:00+00:00","validity_end_date":null,"description":"Pizza
-        cheese, frozen, cut into pieces each weighing not more than 1&nbsp;g, in containers
-        of 5&nbsp;kg or more, of a water content, by weight, of 52% and a fat content,
-        by weight, of 38% or more","number_indents":3,"heading":{"goods_nomenclature_sid":29719,"goods_nomenclature_item_id":"0406000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Cheese
-        and curd","number_indents":0},"chapter":{"goods_nomenclature_sid":29417,"goods_nomenclature_item_id":"0400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Dairy
-        produce; birds''eggs; natural honey; edible products of animal origin, not
-        elsewhere specified or included"},"section":{"numeral":"I","title":"Live animals;
-        animal products","position":1}}},{"_index":"tariff-commodities","_type":"commodity","_id":"88304","_score":1.0,"_source":{"id":88304,"goods_nomenclature_item_id":"0602909110","producline_suffix":"80","validity_start_date":"2007-03-01T00:00:00+00:00","validity_end_date":null,"description":"Potted
-        plants not exceeding 1&nbsp;m in height","number_indents":6,"heading":{"goods_nomenclature_sid":30069,"goods_nomenclature_item_id":"0602000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        live plants (including their roots), cuttings and slips; mushroom spawn","number_indents":0},"chapter":{"goods_nomenclature_sid":30055,"goods_nomenclature_item_id":"0600000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Live
-        trees and other plants; bulbs, roots and the like; cut flowers and ornamental
-        foliage"},"section":{"numeral":"II","title":"Vegetable products","position":2}}},{"_index":"tariff-commodities","_type":"commodity","_id":"88307","_score":1.0,"_source":{"id":88307,"goods_nomenclature_item_id":"0602909910","producline_suffix":"80","validity_start_date":"2007-03-01T00:00:00+00:00","validity_end_date":null,"description":"Potted
-        plants not exceeding 1&nbsp;m in height","number_indents":6,"heading":{"goods_nomenclature_sid":30069,"goods_nomenclature_item_id":"0602000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        live plants (including their roots), cuttings and slips; mushroom spawn","number_indents":0},"chapter":{"goods_nomenclature_sid":30055,"goods_nomenclature_item_id":"0600000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Live
-        trees and other plants; bulbs, roots and the like; cut flowers and ornamental
-        foliage"},"section":{"numeral":"II","title":"Vegetable products","position":2}}},{"_index":"tariff-commodities","_type":"commodity","_id":"70919","_score":1.0,"_source":{"id":70919,"goods_nomenclature_item_id":"0701905000","producline_suffix":"80","validity_start_date":"2000-01-01T00:00:00+00:00","validity_end_date":null,"description":"New,
-        from 1&nbsp;January to 30&nbsp;June","number_indents":3,"heading":{"goods_nomenclature_sid":30241,"goods_nomenclature_item_id":"0701000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Potatoes,
-        fresh or chilled","number_indents":0},"chapter":{"goods_nomenclature_sid":30240,"goods_nomenclature_item_id":"0700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Edible
-        vegetables and certain roots and tubers"},"section":{"numeral":"II","title":"Vegetable
-        products","position":2}}},{"_index":"tariff-commodities","_type":"commodity","_id":"76064","_score":1.0,"_source":{"id":76064,"goods_nomenclature_item_id":"0302112000","producline_suffix":"80","validity_start_date":"2003-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        the species Oncorhynchus mykiss, with heads and gills on, gutted, weighing
-        more than 1,2&nbsp;kg each, or with heads off, gilled and gutted, weighing
-        more than 1&nbsp;kg each","number_indents":3,"heading":{"goods_nomenclature_sid":28402,"goods_nomenclature_item_id":"0302000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fish,
-        fresh or chilled, excluding fish fillets and other fish meat of heading&nbsp;0304","number_indents":0},"chapter":{"goods_nomenclature_sid":28373,"goods_nomenclature_item_id":"0300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Fish
-        and crustaceans, molluscs and other aquatic invertebrates"},"section":{"numeral":"I","title":"Live
-        animals; animal products","position":1}}},{"_index":"tariff-commodities","_type":"commodity","_id":"94028","_score":1.0,"_source":{"id":94028,"goods_nomenclature_item_id":"0303142000","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        the species Oncorhynchus mykiss, with heads and gills on, gutted, weighing
-        more than 1,2&nbsp;kg each, or with heads off, gilled and gutted, weighing
-        more than 1&nbsp;kg each","number_indents":3,"heading":{"goods_nomenclature_sid":28590,"goods_nomenclature_item_id":"0303000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fish,
-        frozen, excluding fish fillets and other fish meat of heading&nbsp;0304","number_indents":0},"chapter":{"goods_nomenclature_sid":28373,"goods_nomenclature_item_id":"0300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Fish
-        and crustaceans, molluscs and other aquatic invertebrates"},"section":{"numeral":"I","title":"Live
-        animals; animal products","position":1}}},{"_index":"tariff-commodities","_type":"commodity","_id":"81280","_score":1.0,"_source":{"id":81280,"goods_nomenclature_item_id":"2933599515","producline_suffix":"80","validity_start_date":"2005-01-01T00:00:00+00:00","validity_end_date":null,"description":"(2_R_)-4-Oxo-4-[3-(trifluoromethyl)-5,6-dihydro[1,2,4]triazolo[4,3-_a_]
-        pyrazin-7(8_H_)-yl]-1-(2,4,5-trifluorophenyl)butyl-2-ammonium phosphate monohydrate","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        products","position":2}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33900","_score":1.0,"_source":{"id":33900,"goods_nomenclature_item_id":"2008501100","producline_suffix":"20","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
+        immediate packings of a net content exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
+        nuts and other edible parts of plants, otherwise prepared or preserved, whether
+        or not containing added sugar or other sweetening matter or spirit, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
+        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
+        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
+        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33907","_score":1.0,"_source":{"id":33907,"goods_nomenclature_item_id":"2008505100","producline_suffix":"10","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
+        immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
+        nuts and other edible parts of plants, otherwise prepared or preserved, whether
+        or not containing added sugar or other sweetening matter or spirit, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
+        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
+        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
+        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33911","_score":1.0,"_source":{"id":33911,"goods_nomenclature_item_id":"2008506100","producline_suffix":"20","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
+        added sugar, in immediate packings of a net content exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
+        nuts and other edible parts of plants, otherwise prepared or preserved, whether
+        or not containing added sugar or other sweetening matter or spirit, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
+        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
+        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
+        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33914","_score":1.0,"_source":{"id":33914,"goods_nomenclature_item_id":"2008507100","producline_suffix":"10","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
+        added sugar, in immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
+        nuts and other edible parts of plants, otherwise prepared or preserved, whether
+        or not containing added sugar or other sweetening matter or spirit, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
+        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
+        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
+        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"80849","_score":1.0,"_source":{"id":80849,"goods_nomenclature_item_id":"2008605000","producline_suffix":"80","validity_start_date":"2005-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
+        added sugar, in immediate packings of a net content exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
+        nuts and other edible parts of plants, otherwise prepared or preserved, whether
+        or not containing added sugar or other sweetening matter or spirit, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
+        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
+        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
+        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"80852","_score":1.0,"_source":{"id":80852,"goods_nomenclature_item_id":"2008606000","producline_suffix":"80","validity_start_date":"2005-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
+        added sugar, in immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
+        nuts and other edible parts of plants, otherwise prepared or preserved, whether
+        or not containing added sugar or other sweetening matter or spirit, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
+        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
+        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
+        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33958","_score":1.0,"_source":{"id":33958,"goods_nomenclature_item_id":"2008701100","producline_suffix":"20","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
+        immediate packings of a net content exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
+        nuts and other edible parts of plants, otherwise prepared or preserved, whether
+        or not containing added sugar or other sweetening matter or spirit, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
+        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
+        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
+        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33965","_score":1.0,"_source":{"id":33965,"goods_nomenclature_item_id":"2008705100","producline_suffix":"10","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
+        immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
+        nuts and other edible parts of plants, otherwise prepared or preserved, whether
+        or not containing added sugar or other sweetening matter or spirit, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
+        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
+        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
+        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33969","_score":1.0,"_source":{"id":33969,"goods_nomenclature_item_id":"2008706100","producline_suffix":"20","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
+        added sugar, in immediate packings of a net content exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
+        nuts and other edible parts of plants, otherwise prepared or preserved, whether
+        or not containing added sugar or other sweetening matter or spirit, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
+        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
+        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
+        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33972","_score":1.0,"_source":{"id":33972,"goods_nomenclature_item_id":"2008707100","producline_suffix":"10","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
+        added sugar, in immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
+        nuts and other edible parts of plants, otherwise prepared or preserved, whether
+        or not containing added sugar or other sweetening matter or spirit, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
+        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
+        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
+        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33991","_score":1.0,"_source":{"id":33991,"goods_nomenclature_item_id":"2008805000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
+        added sugar, in immediate packings of a net content exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
+        nuts and other edible parts of plants, otherwise prepared or preserved, whether
+        or not containing added sugar or other sweetening matter or spirit, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
+        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
+        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
+        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"33992","_score":1.0,"_source":{"id":33992,"goods_nomenclature_item_id":"2008807000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
+        added sugar, in immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
+        nuts and other edible parts of plants, otherwise prepared or preserved, whether
+        or not containing added sugar or other sweetening matter or spirit, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
+        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
+        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
+        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"94874","_score":1.0,"_source":{"id":94874,"goods_nomenclature_item_id":"2008939100","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
+        added sugar, in immediate packings of a net content exceeding 1&nbsp;kg","number_indents":4,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
+        nuts and other edible parts of plants, otherwise prepared or preserved, whether
+        or not containing added sugar or other sweetening matter or spirit, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
+        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
+        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
+        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"94878","_score":1.0,"_source":{"id":94878,"goods_nomenclature_item_id":"2008939300","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
+        added sugar, in immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":4,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
+        nuts and other edible parts of plants, otherwise prepared or preserved, whether
+        or not containing added sugar or other sweetening matter or spirit, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
+        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
+        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
+        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"98037","_score":1.0,"_source":{"id":98037,"goods_nomenclature_item_id":"2008970300","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
+        immediate packings of a net content exceeding 1&nbsp;kg","number_indents":4,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
+        nuts and other edible parts of plants, otherwise prepared or preserved, whether
+        or not containing added sugar or other sweetening matter or spirit, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
+        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
+        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
+        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"98038","_score":1.0,"_source":{"id":98038,"goods_nomenclature_item_id":"2008970500","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
+        immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":4,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
+        nuts and other edible parts of plants, otherwise prepared or preserved, whether
+        or not containing added sugar or other sweetening matter or spirit, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
+        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
+        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
+        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"94903","_score":1.0,"_source":{"id":94903,"goods_nomenclature_item_id":"2008975100","producline_suffix":"30","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
+        immediate packings of a net content exceeding 1&nbsp;kg","number_indents":5,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
+        nuts and other edible parts of plants, otherwise prepared or preserved, whether
+        or not containing added sugar or other sweetening matter or spirit, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
+        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
+        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
+        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"34082","_score":1.0,"_source":{"id":34082,"goods_nomenclature_item_id":"2008994100","producline_suffix":"20","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
+        added sugar, in immediate packings of a net content exceeding 1&nbsp;kg","number_indents":4,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
+        nuts and other edible parts of plants, otherwise prepared or preserved, whether
+        or not containing added sugar or other sweetening matter or spirit, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
+        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
+        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
+        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"34110","_score":1.0,"_source":{"id":34110,"goods_nomenclature_item_id":"2008995100","producline_suffix":"10","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
+        added sugar, in immediate packings of a net content not exceeding 1&nbsp;kg","number_indents":4,"heading":{"goods_nomenclature_sid":33772,"goods_nomenclature_item_id":"2008000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fruit,
+        nuts and other edible parts of plants, otherwise prepared or preserved, whether
+        or not containing added sugar or other sweetening matter or spirit, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":33378,"goods_nomenclature_item_id":"2000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Preparations
+        of vegetables, fruit, nuts or other parts of plants"},"section":{"numeral":"IV","title":"Prepared
+        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
+        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"34515","_score":1.0,"_source":{"id":34515,"goods_nomenclature_item_id":"2102201100","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"In
+        tablet, cube or similar form, or in immediate packings of a net content not
+        exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":34502,"goods_nomenclature_item_id":"2102000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Yeasts
+        (active or inactive); other single-cell micro-organisms, dead (but not including
+        vaccines of heading&nbsp;3002); prepared baking powders","number_indents":0},"chapter":{"goods_nomenclature_sid":34458,"goods_nomenclature_item_id":"2100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        edible preparations"},"section":{"numeral":"IV","title":"Prepared foodstuffs;
+        beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95245","_score":1.0,"_source":{"id":95245,"goods_nomenclature_item_id":"2710196400","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
+        a sulphur content exceeding 0,1% by weight but not exceeding 1% by weight","number_indents":6,"heading":{"goods_nomenclature_sid":35586,"goods_nomenclature_item_id":"2710000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Petroleum
+        oils and oils obtained from bituminous minerals, other than crude; preparations
+        not elsewhere specified or included, containing by weight 70% or more of petroleum
+        oils or of oils obtained from bituminous minerals, these oils being the basic
+        constituents of the preparations","number_indents":0},"chapter":{"goods_nomenclature_sid":35521,"goods_nomenclature_item_id":"2700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Mineral
+        fuels, mineral oils and products of their distillation; bituminous substances;
+        mineral waxes"},"section":{"numeral":"V","title":"Mineral products","position":5}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95246","_score":1.0,"_source":{"id":95246,"goods_nomenclature_item_id":"2710196800","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
+        a sulphur content exceeding 1% by weight","number_indents":6,"heading":{"goods_nomenclature_sid":35586,"goods_nomenclature_item_id":"2710000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Petroleum
+        oils and oils obtained from bituminous minerals, other than crude; preparations
+        not elsewhere specified or included, containing by weight 70% or more of petroleum
+        oils or of oils obtained from bituminous minerals, these oils being the basic
+        constituents of the preparations","number_indents":0},"chapter":{"goods_nomenclature_sid":35521,"goods_nomenclature_item_id":"2700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Mineral
+        fuels, mineral oils and products of their distillation; bituminous substances;
+        mineral waxes"},"section":{"numeral":"V","title":"Mineral products","position":5}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95256","_score":1.0,"_source":{"id":95256,"goods_nomenclature_item_id":"2710203500","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
+        a sulphur content exceeding 0,1% by weight but not exceeding 1% by weight","number_indents":3,"heading":{"goods_nomenclature_sid":35586,"goods_nomenclature_item_id":"2710000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Petroleum
+        oils and oils obtained from bituminous minerals, other than crude; preparations
+        not elsewhere specified or included, containing by weight 70% or more of petroleum
+        oils or of oils obtained from bituminous minerals, these oils being the basic
+        constituents of the preparations","number_indents":0},"chapter":{"goods_nomenclature_sid":35521,"goods_nomenclature_item_id":"2700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Mineral
+        fuels, mineral oils and products of their distillation; bituminous substances;
+        mineral waxes"},"section":{"numeral":"V","title":"Mineral products","position":5}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95257","_score":1.0,"_source":{"id":95257,"goods_nomenclature_item_id":"2710203900","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
+        a sulphur content exceeding 1% by weight","number_indents":3,"heading":{"goods_nomenclature_sid":35586,"goods_nomenclature_item_id":"2710000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Petroleum
+        oils and oils obtained from bituminous minerals, other than crude; preparations
+        not elsewhere specified or included, containing by weight 70% or more of petroleum
+        oils or of oils obtained from bituminous minerals, these oils being the basic
+        constituents of the preparations","number_indents":0},"chapter":{"goods_nomenclature_sid":35521,"goods_nomenclature_item_id":"2700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Mineral
+        fuels, mineral oils and products of their distillation; bituminous substances;
+        mineral waxes"},"section":{"numeral":"V","title":"Mineral products","position":5}}},{"_index":"tariff-commodities","_type":"commodity","_id":"64989","_score":1.0,"_source":{"id":64989,"goods_nomenclature_item_id":"2712201000","producline_suffix":"80","validity_start_date":"1997-01-01T00:00:00+00:00","validity_end_date":null,"description":"Synthetic
+        paraffin wax of a molecular weight of 460&nbsp;or more but not exceeding 1&nbsp;560","number_indents":2,"heading":{"goods_nomenclature_sid":35685,"goods_nomenclature_item_id":"2712000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Petroleum
+        jelly; paraffin wax, microcrystalline petroleum wax, slack wax, ozokerite,
+        lignite wax, peat wax, other mineral waxes, and similar products obtained
+        by synthesis or by other processes, whether or not coloured","number_indents":0},"chapter":{"goods_nomenclature_sid":35521,"goods_nomenclature_item_id":"2700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Mineral
+        fuels, mineral oils and products of their distillation; bituminous substances;
+        mineral waxes"},"section":{"numeral":"V","title":"Mineral products","position":5}}},{"_index":"tariff-commodities","_type":"commodity","_id":"64992","_score":1.0,"_source":{"id":64992,"goods_nomenclature_item_id":"2712909100","producline_suffix":"80","validity_start_date":"1997-01-01T00:00:00+00:00","validity_end_date":null,"description":"Blend
+        of 1-alkenes containing by weight 80% or more of 1-alkenes of a chain-length
+        of 24&nbsp;carbon atoms or more but not exceeding 28&nbsp;carbon atoms","number_indents":4,"heading":{"goods_nomenclature_sid":35685,"goods_nomenclature_item_id":"2712000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Petroleum
+        jelly; paraffin wax, microcrystalline petroleum wax, slack wax, ozokerite,
+        lignite wax, peat wax, other mineral waxes, and similar products obtained
+        by synthesis or by other processes, whether or not coloured","number_indents":0},"chapter":{"goods_nomenclature_sid":35521,"goods_nomenclature_item_id":"2700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Mineral
+        fuels, mineral oils and products of their distillation; bituminous substances;
+        mineral waxes"},"section":{"numeral":"V","title":"Mineral products","position":5}}},{"_index":"tariff-commodities","_type":"commodity","_id":"64994","_score":1.0,"_source":{"id":64994,"goods_nomenclature_item_id":"2712909910","producline_suffix":"80","validity_start_date":"1997-01-01T00:00:00+00:00","validity_end_date":"2014-06-30T00:00:00+00:00","description":"Blend
+        of 1-alkenes containing 80% by weight or more of 1-alkenes of a chain-length
+        of 20 and 22 carbon atoms","number_indents":5,"heading":{"goods_nomenclature_sid":35685,"goods_nomenclature_item_id":"2712000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Petroleum
+        jelly; paraffin wax, microcrystalline petroleum wax, slack wax, ozokerite,
+        lignite wax, peat wax, other mineral waxes, and similar products obtained
+        by synthesis or by other processes, whether or not coloured","number_indents":0},"chapter":{"goods_nomenclature_sid":35521,"goods_nomenclature_item_id":"2700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Mineral
+        fuels, mineral oils and products of their distillation; bituminous substances;
+        mineral waxes"},"section":{"numeral":"V","title":"Mineral products","position":5}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97468","_score":1.0,"_source":{"id":97468,"goods_nomenclature_item_id":"2811198030","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"Phosphorous
+        acid (CAS RN 10294-56-1)/phosphonic acid (CAS RN 13598-36-2) used as an ingredient
+        for production of additives used in poly(vinyl chloride) industry","number_indents":4,"heading":{"goods_nomenclature_sid":35783,"goods_nomenclature_item_id":"2811000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        inorganic acids and other inorganic oxygen compounds of non-metals","number_indents":0},"chapter":{"goods_nomenclature_sid":35719,"goods_nomenclature_item_id":"2800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Inorganic
+        chemicals; organic or inorganic compounds of precious metals, of rare-earth
+        metals, of radioactive elements or of isotopes"},"section":{"numeral":"VI","title":"Products
+        of the chemical or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"88344","_score":1.0,"_source":{"id":88344,"goods_nomenclature_item_id":"2811220020","producline_suffix":"80","validity_start_date":"2007-07-01T00:00:00+00:00","validity_end_date":"2014-06-30T00:00:00+00:00","description":"Microspheres
+        of amorphous silicon of a particle size of 5&nbsp;\u03bcm (\u00b1 1&nbsp;\u00b5m),
+        for use in the manufacture of cosmetic products","number_indents":3,"heading":{"goods_nomenclature_sid":35783,"goods_nomenclature_item_id":"2811000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        inorganic acids and other inorganic oxygen compounds of non-metals","number_indents":0},"chapter":{"goods_nomenclature_sid":35719,"goods_nomenclature_item_id":"2800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Inorganic
+        chemicals; organic or inorganic compounds of precious metals, of rare-earth
+        metals, of radioactive elements or of isotopes"},"section":{"numeral":"VI","title":"Products
+        of the chemical or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"88345","_score":1.0,"_source":{"id":88345,"goods_nomenclature_item_id":"2811220030","producline_suffix":"80","validity_start_date":"2007-07-01T00:00:00+00:00","validity_end_date":null,"description":"Balls
+        of porous white silica of a particle size of more than 1&nbsp;\u00b5m for
+        use in the manufacture of cosmetic products","number_indents":3,"heading":{"goods_nomenclature_sid":35783,"goods_nomenclature_item_id":"2811000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        inorganic acids and other inorganic oxygen compounds of non-metals","number_indents":0},"chapter":{"goods_nomenclature_sid":35719,"goods_nomenclature_item_id":"2800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Inorganic
+        chemicals; organic or inorganic compounds of precious metals, of rare-earth
+        metals, of radioactive elements or of isotopes"},"section":{"numeral":"VI","title":"Products
+        of the chemical or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93650","_score":1.0,"_source":{"id":93650,"goods_nomenclature_item_id":"2818109110","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"Sintered
+        corundum with micro crystalline structure, containing by weight: <br/>-&nbsp;94%
+        or more, but not more than 98,5% of \u03b1-Al<sub>2</sub>O<sub>3</sub>, <br/>-&nbsp;2%
+        (\u00b1 1,5%) of magnesium spinel, <br/>-&nbsp;1% (\u00b1 0,6%) of yttrium
+        oxide and <br/>-&nbsp;2%&nbsp;(\u00b1 1,2%) of each lanthanum oxide and neodymium
+        oxide <br/>with less than 50% of the total weight having a particle size of
+        more than 10&nbsp;mm","number_indents":4,"heading":{"goods_nomenclature_sid":35831,"goods_nomenclature_item_id":"2818000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
+        oxide (including artificial corundum); aluminium hydroxide","number_indents":0},"chapter":{"goods_nomenclature_sid":35719,"goods_nomenclature_item_id":"2800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Inorganic
+        chemicals; organic or inorganic compounds of precious metals, of rare-earth
+        metals, of radioactive elements or of isotopes"},"section":{"numeral":"VI","title":"Products
+        of the chemical or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96862","_score":1.0,"_source":{"id":96862,"goods_nomenclature_item_id":"2825100010","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"Hydroxylammonium
+        chloride (CAS RN 5470-11-1)","number_indents":2,"heading":{"goods_nomenclature_sid":35856,"goods_nomenclature_item_id":"2825000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Hydrazine
+        and hydroxylamine and their inorganic salts; other inorganic bases; other
+        metal oxides, hydroxides and peroxides","number_indents":0},"chapter":{"goods_nomenclature_sid":35719,"goods_nomenclature_item_id":"2800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Inorganic
+        chemicals; organic or inorganic compounds of precious metals, of rare-earth
+        metals, of radioactive elements or of isotopes"},"section":{"numeral":"VI","title":"Products
+        of the chemical or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"65007","_score":1.0,"_source":{"id":65007,"goods_nomenclature_item_id":"2825901100","producline_suffix":"80","validity_start_date":"1997-01-01T00:00:00+00:00","validity_end_date":null,"description":"Calcium
+        hydroxide of a purity of 98% or more calculated on the dry weight, in the
+        form of particles of which:-&nbsp;not more than 1% by weight have a particle-size
+        exceeding 75&nbsp;micrometres and-&nbsp;not more than 4% by weight have a
+        particle-size of less than 1,3&nbsp;micrometres","number_indents":3,"heading":{"goods_nomenclature_sid":35856,"goods_nomenclature_item_id":"2825000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Hydrazine
+        and hydroxylamine and their inorganic salts; other inorganic bases; other
+        metal oxides, hydroxides and peroxides","number_indents":0},"chapter":{"goods_nomenclature_sid":35719,"goods_nomenclature_item_id":"2800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Inorganic
+        chemicals; organic or inorganic compounds of precious metals, of rare-earth
+        metals, of radioactive elements or of isotopes"},"section":{"numeral":"VI","title":"Products
+        of the chemical or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"55656","_score":1.0,"_source":{"id":55656,"goods_nomenclature_item_id":"2204309200","producline_suffix":"20","validity_start_date":"1995-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a density of 1,33&nbsp;g/cm<sup>3</sup>&nbsp;or less at 20&nbsp;\u00b0C and
+        of an actual alcoholic strength by volume not exceeding 1%&nbsp;vol","number_indents":3,"heading":{"goods_nomenclature_sid":34654,"goods_nomenclature_item_id":"2204000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Wine
+        of fresh grapes, including fortified wines; grape must other than that of
+        heading No  2009","number_indents":0},"chapter":{"goods_nomenclature_sid":34628,"goods_nomenclature_item_id":"2200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Beverages,
+        spirits and vinegar"},"section":{"numeral":"IV","title":"Prepared foodstuffs;
+        beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95151","_score":1.0,"_source":{"id":95151,"goods_nomenclature_item_id":"2403110000","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"Water-pipe
+        tobacco specified in subheading note 1 to this chapter","number_indents":2,"heading":{"goods_nomenclature_sid":35287,"goods_nomenclature_item_id":"2403000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        manufactured tobacco and manufactured tobacco substitutes; ''homogenised''
+        or ''reconstituted'' tobacco; tobacco extracts and essences","number_indents":0},"chapter":{"goods_nomenclature_sid":35246,"goods_nomenclature_item_id":"2400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Tobacco
+        and manufactured tobacco substitutes"},"section":{"numeral":"IV","title":"Prepared
+        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
+        substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92836","_score":1.0,"_source":{"id":92836,"goods_nomenclature_item_id":"2106108030","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
+        more than 1% milk fats, 1% other fats or more than 5% sugars","number_indents":3,"heading":{"goods_nomenclature_sid":34567,"goods_nomenclature_item_id":"2106000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Food
+        preparations not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":34458,"goods_nomenclature_item_id":"2100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        edible preparations"},"section":{"numeral":"IV","title":"Prepared foodstuffs;
+        beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92846","_score":1.0,"_source":{"id":92846,"goods_nomenclature_item_id":"2106909826","producline_suffix":"20","validity_start_date":"2010-06-01T00:00:00+00:00","validity_end_date":null,"description":"In
+        immediate packings of a net capacity of 1&nbsp;kg or less","number_indents":5,"heading":{"goods_nomenclature_sid":34567,"goods_nomenclature_item_id":"2106000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Food
+        preparations not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":34458,"goods_nomenclature_item_id":"2100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        edible preparations"},"section":{"numeral":"IV","title":"Prepared foodstuffs;
+        beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91914","_score":1.0,"_source":{"id":91914,"goods_nomenclature_item_id":"2204210600","producline_suffix":"10","validity_start_date":"2010-01-01T00:00:00+00:00","validity_end_date":null,"description":"Wine,
+        other than that referred to in subheading 2204&nbsp;10, in bottles with ''mushroom''
+        stoppers held in place by ties or fastenings; wine, otherwise put up, with
+        an excess pressure due to carbon dioxide in solution of not less than 1&nbsp;bar
+        but less than 3&nbsp;bar, measured at a temperature of 20&nbsp;\u00b0C","number_indents":3,"heading":{"goods_nomenclature_sid":34654,"goods_nomenclature_item_id":"2204000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Wine
+        of fresh grapes, including fortified wines; grape must other than that of
+        heading No  2009","number_indents":0},"chapter":{"goods_nomenclature_sid":34628,"goods_nomenclature_item_id":"2200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Beverages,
+        spirits and vinegar"},"section":{"numeral":"IV","title":"Prepared foodstuffs;
+        beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"34813","_score":1.0,"_source":{"id":34813,"goods_nomenclature_item_id":"2204291000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Wine,
+        other than that referred to in subheading 2204&nbsp;10, in bottles with ''mushroom''
+        stoppers held in place by ties or fastenings; wine, otherwise put up, with
+        an excess pressure due to carbon dioxide in solution of not less than 1&nbsp;bar
+        but less than 3&nbsp;bar, measured at a temperature of 20&nbsp;\u00b0C","number_indents":3,"heading":{"goods_nomenclature_sid":34654,"goods_nomenclature_item_id":"2204000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Wine
+        of fresh grapes, including fortified wines; grape must other than that of
+        heading No  2009","number_indents":0},"chapter":{"goods_nomenclature_sid":34628,"goods_nomenclature_item_id":"2200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Beverages,
+        spirits and vinegar"},"section":{"numeral":"IV","title":"Prepared foodstuffs;
+        beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes","position":4}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91426","_score":1.0,"_source":{"id":91426,"goods_nomenclature_item_id":"2923900045","producline_suffix":"80","validity_start_date":"2010-01-01T00:00:00+00:00","validity_end_date":null,"description":"Tetrabutylammonium
+        hydroxide in the form of an aqueous solution containing 55% (\u00b1&nbsp;
+        1%) by weight of tetrabutylammonium hydroxide (CAS RN 2052-49-5)","number_indents":2,"heading":{"goods_nomenclature_sid":36961,"goods_nomenclature_item_id":"2923000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Quaternary
+        ammonium salts and hydroxides; lecithins and other phosphoaminolipids","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93678","_score":1.0,"_source":{"id":93678,"goods_nomenclature_item_id":"2923900075","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"Tetraethylammonium
+        hydroxide, in the form of an aqueous solution containing: <br/>-&nbsp;35%
+        (\u00b1&nbsp;0,5%) by weight of tetraethylammonium hydroxide, <br/>-&nbsp;not
+        more than 1&nbsp;000&nbsp;mg/kg of chloride, <br/>-&nbsp;not more than 2&nbsp;mg/kg&nbsp;of
+        iron and <br/>-&nbsp;not more than 10&nbsp;mg/kg&nbsp;of potassium","number_indents":2,"heading":{"goods_nomenclature_sid":36961,"goods_nomenclature_item_id":"2923000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Quaternary
+        ammonium salts and hydroxides; lecithins and other phosphoaminolipids","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"81610","_score":1.0,"_source":{"id":81610,"goods_nomenclature_item_id":"2924190050","producline_suffix":"80","validity_start_date":"2005-07-01T00:00:00+00:00","validity_end_date":null,"description":"Acrylamide
+        (CAS RN 79-06-1)","number_indents":3,"heading":{"goods_nomenclature_sid":36969,"goods_nomenclature_item_id":"2924000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Carboxyamide-function
+        compounds; amide-function compounds of carbonic acid","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90470","_score":1.0,"_source":{"id":90470,"goods_nomenclature_item_id":"2924299815","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"Acetochlor
+        (ISO) (CAS RN 34256-82-1)","number_indents":4,"heading":{"goods_nomenclature_sid":36969,"goods_nomenclature_item_id":"2924000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Carboxyamide-function
+        compounds; amide-function compounds of carbonic acid","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93681","_score":1.0,"_source":{"id":93681,"goods_nomenclature_item_id":"2924299845","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"Propoxur
+        (ISO) (CAS RN 114-26-1)","number_indents":4,"heading":{"goods_nomenclature_sid":36969,"goods_nomenclature_item_id":"2924000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Carboxyamide-function
+        compounds; amide-function compounds of carbonic acid","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93684","_score":1.0,"_source":{"id":93684,"goods_nomenclature_item_id":"2924299860","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"N,N''-(2-Chloro-5-methyl-1,4-phenylene)bis[3-oxobutyramide]
+        (CAS RN 41131-65-1)","number_indents":4,"heading":{"goods_nomenclature_sid":36969,"goods_nomenclature_item_id":"2924000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Carboxyamide-function
+        compounds; amide-function compounds of carbonic acid","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"37014","_score":1.0,"_source":{"id":37014,"goods_nomenclature_item_id":"2926200000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"1-Cyanoguanidine
+        (dicyandiamide)","number_indents":1,"heading":{"goods_nomenclature_sid":37012,"goods_nomenclature_item_id":"2926000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Nitrile-function
+        compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"88354","_score":1.0,"_source":{"id":88354,"goods_nomenclature_item_id":"2926909561","producline_suffix":"80","validity_start_date":"2007-07-01T00:00:00+00:00","validity_end_date":null,"description":"m-(1-Cyanoethyl)benzoic
+        acid (CAS RN 5537-71-3)","number_indents":3,"heading":{"goods_nomenclature_sid":37012,"goods_nomenclature_item_id":"2926000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Nitrile-function
+        compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91427","_score":1.0,"_source":{"id":91427,"goods_nomenclature_item_id":"2926909563","producline_suffix":"80","validity_start_date":"2010-01-01T00:00:00+00:00","validity_end_date":null,"description":"1-(Cyanoacetyl)-3-ethylurea
+        (CAS RN 41078-06-2)","number_indents":3,"heading":{"goods_nomenclature_sid":37012,"goods_nomenclature_item_id":"2926000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Nitrile-function
+        compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97938","_score":1.0,"_source":{"id":97938,"goods_nomenclature_item_id":"2927000085","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"C,C\u2019-Azodi(formamide)
+        (CAS RN 123-77-3) with:<br/>- a pH of 6,5 or more but not more than 7,5, and<br/>-
+        a semicarbazide (CAS RN 57-56-7) content of not more than 1 500 mg/kg as determined
+        by liquid chromatography mass spectrometry (LC-MS),<br/>- decomposition temperature
+        range of 195 \u00b0C - 205 \u00b0C,<br/>- specific gravity 1,64 \u2013 1,66,
+        and<br/>- combustion heat 215 - 220 Kcal/mol","number_indents":1,"heading":{"goods_nomenclature_sid":37029,"goods_nomenclature_item_id":"2927000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Diazo-,
+        azo- or azoxy-compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97965","_score":1.0,"_source":{"id":97965,"goods_nomenclature_item_id":"2928009055","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"Aminoguanidinium
+        hydrogen carbonate (CAS RN 2582-30-1)","number_indents":2,"heading":{"goods_nomenclature_sid":37033,"goods_nomenclature_item_id":"2928000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        derivatives of hydrazine or of hydroxylamine","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90479","_score":1.0,"_source":{"id":90479,"goods_nomenclature_item_id":"2929100080","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"1,3-Bis(isocyanatomethyl)
+        benzene (CAS RN 3634-83-1)","number_indents":2,"heading":{"goods_nomenclature_sid":37042,"goods_nomenclature_item_id":"2929000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Compounds
+        with other nitrogen function","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93687","_score":1.0,"_source":{"id":93687,"goods_nomenclature_item_id":"2930909910","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"2,3-Bis((2-mercaptoethyl)thio)-1-propanethiol
+        (CAS RN 131538-00-6)","number_indents":3,"heading":{"goods_nomenclature_sid":37063,"goods_nomenclature_item_id":"2930000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Organo-sulphur
+        compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96336","_score":1.0,"_source":{"id":96336,"goods_nomenclature_item_id":"2930909918","producline_suffix":"80","validity_start_date":"2012-07-01T00:00:00+00:00","validity_end_date":null,"description":"1-Methyl-5-[3-methyl-4-[4-[(trifluoromethyl)thio]phenoxy]phenyl]biuret,
+        (CAS RN 106310-17-2)","number_indents":3,"heading":{"goods_nomenclature_sid":37063,"goods_nomenclature_item_id":"2930000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Organo-sulphur
+        compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91609","_score":1.0,"_source":{"id":91609,"goods_nomenclature_item_id":"2930909940","producline_suffix":"80","validity_start_date":"2010-01-01T00:00:00+00:00","validity_end_date":null,"description":"3,3\u0384-Thiodi(propionic
+        acid) (CAS RN 111-17-1)","number_indents":3,"heading":{"goods_nomenclature_sid":37063,"goods_nomenclature_item_id":"2930000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Organo-sulphur
+        compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93136","_score":1.0,"_source":{"id":93136,"goods_nomenclature_item_id":"2930909950","producline_suffix":"80","validity_start_date":"2011-01-01T00:00:00+00:00","validity_end_date":null,"description":"[S-(R*,R*)]-2-Amino-1-[4-(methylthio)-phenyl]-1,3-propanediol
+        (CAS RN 23150-35-8)","number_indents":3,"heading":{"goods_nomenclature_sid":37063,"goods_nomenclature_item_id":"2930000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Organo-sulphur
+        compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97492","_score":1.0,"_source":{"id":97492,"goods_nomenclature_item_id":"2931909035","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"(Z)-Prop-1-en-1-ylphosphonic
+        acid (CAS RN 25383-06-6)","number_indents":3,"heading":{"goods_nomenclature_sid":37096,"goods_nomenclature_item_id":"2931000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        organo-inorganic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96256","_score":1.0,"_source":{"id":96256,"goods_nomenclature_item_id":"2931909075","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"Tetrakis(hydroxymethyl)phosphonium
+        chloride (CAS RN 124-64-1)","number_indents":3,"heading":{"goods_nomenclature_sid":37096,"goods_nomenclature_item_id":"2931000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        organo-inorganic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91131","_score":1.0,"_source":{"id":91131,"goods_nomenclature_item_id":"2932190041","producline_suffix":"80","validity_start_date":"2009-07-01T00:00:00+00:00","validity_end_date":null,"description":"2,2&nbsp;di(tetrahydrofuryl)propane
+        (CAS RN 89686-69-1)","number_indents":3,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95508","_score":1.0,"_source":{"id":95508,"goods_nomenclature_item_id":"2932201000","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"Phenolphthalein;
+        1-hydroxy-4-[1-(4-hydroxy-3-methoxycarbonyl-1-naphthyl)-3-oxo-1H,3H-benzo[de]isochromen-1-yl]-6-octadecyloxy-2-naphthoic
+        acid; 3\u2032-chloro-6\u2032-cyclohexylaminospiro[isobenzofuran-1(3H),9\u2032-xanthen]-3-one;
+        6\u2032-(N-ethyl-p-toluidino)-2\u2032-methylspiro[isobenzofuran-1(3H),9\u2032-xanthen]-3-one;
+        methyl-6-docosyloxy-1-hydroxy-4-[1-(4-hydroxy-3-methyl-1-phenanthryl)-3-oxo-1H,3H-naphtho[1,8-cd]pyran-1-yl]naphthalene-2-carboxylate","number_indents":2,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95512","_score":1.0,"_source":{"id":95512,"goods_nomenclature_item_id":"2932209010","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"2\u0384-Anilino-6\u0384-[ethyl(isopentyl)amino]-3\u0384-methylspiro[isobenzofuran
+        -1(3_H_),9\u0384-xanthen]-3-one","number_indents":3,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95513","_score":1.0,"_source":{"id":95513,"goods_nomenclature_item_id":"2932209035","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"6\u0384-Diethylamino-3\u0384-methyl-2\u0384-(2,4-xylidino)spiro[isobenzofuran
+        -1(3_H_),9\u0384-xanthen]-3-one","number_indents":3,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95558","_score":1.0,"_source":{"id":95558,"goods_nomenclature_item_id":"2932209060","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"6\u2019-(Diethylamino)-3\u2019-methyl-2\u2019-(phenylamino)-spiro[isobenzofuran-1(3H),9\u2019-[9H]xanthen]-3-one","number_indents":3,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95557","_score":1.0,"_source":{"id":95557,"goods_nomenclature_item_id":"2932209070","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"3\u2032,6\u2032-Bis(ethylamino)-2'',7''-dimethylspiro[isobenzofuran-1(3_H_),9''-
+        [9_H_]-xanthen]-3-one (CAS RN 41382-37-0)","number_indents":3,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95556","_score":1.0,"_source":{"id":95556,"goods_nomenclature_item_id":"2932209071","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"6\u2019-(Dibutylamino)-3\u2019-methyl-2\u2019-(phenylamino)-spiro[isobenzofuran-1(3H),9\u2019-[9H]xanthen]-3-one","number_indents":3,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95522","_score":1.0,"_source":{"id":95522,"goods_nomenclature_item_id":"2932209072","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"2\u2032-[Bis(phenylmethyl)amino]-6\u2032-(diethylamino)-spiro[isobenzofuran-1(3H),9\u2032-[9H]xanthen]-3-one","number_indents":3,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"59605","_score":1.0,"_source":{"id":59605,"goods_nomenclature_item_id":"2932920000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"1-(1,3-Benzodioxol-5-yl)propan-2-one","number_indents":2,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96338","_score":1.0,"_source":{"id":96338,"goods_nomenclature_item_id":"2932990020","producline_suffix":"80","validity_start_date":"2012-07-01T00:00:00+00:00","validity_end_date":null,"description":"Ethyl-2-methyl-1,3-dioxolane-2-acetate
+        (CAS RN 6413-10-1)","number_indents":3,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97493","_score":1.0,"_source":{"id":97493,"goods_nomenclature_item_id":"2932990025","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"1-(2,2-Difluorobenzo[d][1,3]dioxol-5-yl)cyclopropanecarboxylic
+        acid (CAS RN 862574-88-7)","number_indents":3,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97944","_score":1.0,"_source":{"id":97944,"goods_nomenclature_item_id":"2932990055","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"6-Fluoro-3,4-dihydro-2H-1-benzopyran-2-carboxylic
+        acid (CAS RN 99199-60-7)","number_indents":3,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"81614","_score":1.0,"_source":{"id":81614,"goods_nomenclature_item_id":"2933199030","producline_suffix":"80","validity_start_date":"2005-07-01T00:00:00+00:00","validity_end_date":null,"description":"3-methyl-1-p-tolyl-5-pyrazolone
+        (CAS RN 86-92-0)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
         compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92669","_score":1.0,"_source":{"id":92669,"goods_nomenclature_item_id":"2933599545","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"1-[3-(Hydroxymethyl)pyridin-2-yl]-4-methyl-2-phenylpiperazine
-        (CAS RN 61337-89-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90724","_score":1.0,"_source":{"id":90724,"goods_nomenclature_item_id":"2933199070","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"4,5-Diamino-1-(2-hydroxyethyl)-pyrazolsulphate
+        (CAS RN 155601-30-2)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
         compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92670","_score":1.0,"_source":{"id":92670,"goods_nomenclature_item_id":"2933599550","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"2-(2-Piperazin-1-ylethoxy)ethanol
-        (CAS RN 13349-82-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96841","_score":1.0,"_source":{"id":96841,"goods_nomenclature_item_id":"2933199080","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"3-(4,5-Dihydro-3-methyl-5-oxo-1H-pyrazol-1-yl)benzenesulphonic
+        acid (CAS RN 119-17-5)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
         compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92672","_score":1.0,"_source":{"id":92672,"goods_nomenclature_item_id":"2933599565","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"1-Chloromethyl-4-fluoro-1,4-diazoniabicyclo[2.2.2]octane
-        bis(tetrafluoroborate) (CAS RN 140681-55-6)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97494","_score":1.0,"_source":{"id":97494,"goods_nomenclature_item_id":"2933199085","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"Allyl
+        5-amino-4-(2-methylphenyl)-3-oxo-2,3-dihydro-1H-1-pyrazolcarbothioat (CAS
+        RN 473799-16-5)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
         compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"75256","_score":1.0,"_source":{"id":75256,"goods_nomenclature_item_id":"2933599570","producline_suffix":"80","validity_start_date":"2002-07-01T00:00:00+00:00","validity_end_date":null,"description":"_N_-(4-Ethyl-2,3-dioxopiperazin-1-ylcarbonyl)-D-2-phenylglycine
-        (CAS RN 63422-71-9)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"86726","_score":1.0,"_source":{"id":86726,"goods_nomenclature_item_id":"2933210050","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"1-Bromo-3-chloro-5,5-dimethylhydantoin
+        (CAS RN 16079-88-2)","number_indents":3,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
         compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92673","_score":1.0,"_source":{"id":92673,"goods_nomenclature_item_id":"2933599575","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"(2R,3S/2S,3R)-3-(6-Chloro-5-fluoro
-        pyrimidin-4-yl)-2-(2,4-difluorophenyl)-1-(1H-1,2,4-triazol-1-yl)butan-2-ol
-        hydrochloride (CAS RN 188416-20-8)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"88367","_score":1.0,"_source":{"id":88367,"goods_nomenclature_item_id":"2933210070","producline_suffix":"80","validity_start_date":"2007-07-01T00:00:00+00:00","validity_end_date":null,"description":"\u03b1-(4-Methoxybenzoyl)-\u03b1-(1-benzyl-5-ethoxy-3-hydantoinyl)-2-chloro-5-dodecyloxycarbonylacetanilide
+        (CAS RN 70950-45-7)","number_indents":3,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
         compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96844","_score":1.0,"_source":{"id":96844,"goods_nomenclature_item_id":"2933599577","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"3-(Trifluoromethyl)-5,6,7,8-tetrahydro[1,2,4]triazolo[4,3-a]pyrazine
-        hydrochloride (1:1) (CAS RN 762240-92-6)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97876","_score":1.0,"_source":{"id":97876,"goods_nomenclature_item_id":"2933299015","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"Ethyl
+        4-(1-hydroxy-1-methylethyl)-2-propylimidazole-5-carboxylate (CAS RN 144689-93-0)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
         compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"94001","_score":1.0,"_source":{"id":94001,"goods_nomenclature_item_id":"2933698025","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"1,3,5-Triazine-2,4,6-triamine
-        monophosphate&nbsp;(CAS RN 20208-95-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97878","_score":1.0,"_source":{"id":97878,"goods_nomenclature_item_id":"2933299035","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"1-Trityl-4-formylimidazole&nbsp;(CAS
+        RN 33016-47-6)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
         compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93186","_score":1.0,"_source":{"id":93186,"goods_nomenclature_item_id":"2933790070","producline_suffix":"80","validity_start_date":"2011-01-01T00:00:00+00:00","validity_end_date":null,"description":"(S)-N-[(Diethylamino)methyl]-alpha-ethyl-2-oxo-1-pyrrolidineacetamide
-        L-(+)-tartrate (CAS RN 754186-36-2)","number_indents":3,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"57465","_score":1.0,"_source":{"id":57465,"goods_nomenclature_item_id":"2933299040","producline_suffix":"80","validity_start_date":"1995-01-01T00:00:00+00:00","validity_end_date":null,"description":"Triflumizole
+        (ISO) (CAS RN 68694-11-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
         compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"94005","_score":1.0,"_source":{"id":94005,"goods_nomenclature_item_id":"2933998013","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"5-Difluormethoxy-2-mercapto-1-H-benzimidazole&nbsp;(CAS
-        RN 97963-62-7)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97968","_score":1.0,"_source":{"id":97968,"goods_nomenclature_item_id":"2933299045","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prochloraz
+        copper chloride (ISO) (CAS RN 156065-03-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
         compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90498","_score":1.0,"_source":{"id":90498,"goods_nomenclature_item_id":"2933998015","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"2-(2_H_-Benzotriazol-2-yl)-4,6-di-_tert_-pentylphenol
-        (CAS RN 25973-55-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93973","_score":1.0,"_source":{"id":93973,"goods_nomenclature_item_id":"2933299060","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"1-Cyano-2-methyl-1-[2-(5-methylimidazol-4-ylmethylthio)ethyl]isothiourea&nbsp;(CAS
+        RN 52378-40-2)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
         compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90499","_score":1.0,"_source":{"id":90499,"goods_nomenclature_item_id":"2933998020","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"2-(2_H_-Benzotriazol-2-yl)-4,6-bis(1-methyl-1-phenylethyl)phenol","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"67104","_score":1.0,"_source":{"id":67104,"goods_nomenclature_item_id":"2846100010","producline_suffix":"80","validity_start_date":"1997-07-01T00:00:00+00:00","validity_end_date":null,"description":"Rare-earth
+        concentrate containing by weight 60% or more but not more than 75% of rare-earth
+        oxides and not more than 1% each of zirconium oxide, aluminium oxide or iron
+        oxide, and having a loss on ignition of 5% or more by weight","number_indents":2,"heading":{"goods_nomenclature_sid":36137,"goods_nomenclature_item_id":"2846000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Compounds,
+        inorganic or organic, of rare-earth metals, of yttrium or of scandium or of
+        mixtures of these metals","number_indents":0},"chapter":{"goods_nomenclature_sid":35719,"goods_nomenclature_item_id":"2800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Inorganic
+        chemicals; organic or inorganic compounds of precious metals, of rare-earth
+        metals, of radioactive elements or of isotopes"},"section":{"numeral":"VI","title":"Products
+        of the chemical or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97469","_score":1.0,"_source":{"id":97469,"goods_nomenclature_item_id":"2903399025","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"2,3,3,3-Tetrafluoroprop-1-ene
+        (CAS RN 754-12-1)","number_indents":4,"heading":{"goods_nomenclature_sid":36225,"goods_nomenclature_item_id":"2903000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Halogenated
+        derivatives of hydrocarbons","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96846","_score":1.0,"_source":{"id":96846,"goods_nomenclature_item_id":"2933998022","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"(2S)-2-Benzyl-N,N-dimethylaziridine-1-sulfonamide
-        (CAS RN 902146-43-4)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"85177","_score":1.0,"_source":{"id":85177,"goods_nomenclature_item_id":"2903399050","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"1,1,1,3,3-Pentafluoropropane
+        (CAS RN 460-73-1)","number_indents":4,"heading":{"goods_nomenclature_sid":36225,"goods_nomenclature_item_id":"2903000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Halogenated
+        derivatives of hydrocarbons","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92676","_score":1.0,"_source":{"id":92676,"goods_nomenclature_item_id":"2933998037","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"8-Chloro-5,10-dihydro-11H-dibenzo
-        [b,e] [1,4]diazepin-11-one (CAS RN 50892-62-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91124","_score":1.0,"_source":{"id":91124,"goods_nomenclature_item_id":"2903399075","producline_suffix":"80","validity_start_date":"2009-07-01T00:00:00+00:00","validity_end_date":null,"description":"Trans-1,3,3,3-tetrafluoroprop-1-ene
+        (CAS RN 1645-83-6)","number_indents":4,"heading":{"goods_nomenclature_sid":36225,"goods_nomenclature_item_id":"2903000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Halogenated
+        derivatives of hydrocarbons","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97874","_score":1.0,"_source":{"id":97874,"goods_nomenclature_item_id":"2933998053","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"Potassium
-        (S)-5-(tert-butoxycarbonyl)-5-azaspiro[2.4]heptane-6-carboxylate (CUS&nbsp;0133723-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96418","_score":1.0,"_source":{"id":96418,"goods_nomenclature_item_id":"2903730010","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":"2014-06-30T00:00:00+00:00","description":"1,1-Dichloro-1-fluoroethane
+        (HCFC-141b)","number_indents":3,"heading":{"goods_nomenclature_sid":36225,"goods_nomenclature_item_id":"2903000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Halogenated
+        derivatives of hydrocarbons","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97875","_score":1.0,"_source":{"id":97875,"goods_nomenclature_item_id":"2933998057","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"2-(5-Methoxyindol-3-yl)ethylamine
-        (CAS RN 608-07-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95391","_score":1.0,"_source":{"id":95391,"goods_nomenclature_item_id":"2903899010","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"1,6,7,8,9,14,15,16,17,17,18,18-Dodecachloropentacyclo[12.2.1.1<sup>6</sup><sup>,</sup><sup>9</sup>.0<sup>2</sup><sup>,</sup><sup>1</sup><sup>3</sup>.0<sup>5</sup><sup>,</sup><sup>1</sup><sup>0</sup>]octadeca-7,15-diene,
+        (CAS RN 13560-89-9)","number_indents":4,"heading":{"goods_nomenclature_sid":36225,"goods_nomenclature_item_id":"2903000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Halogenated
+        derivatives of hydrocarbons","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93695","_score":1.0,"_source":{"id":93695,"goods_nomenclature_item_id":"2933998064","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"((3R)-1-{(1R,2R)-2-[2-(3,4-Dimethoxyphenyl)
-        ethoxy]cyclohexyl}pyrrolidin-3-ol.hydrochloride (CAS RN 748810-28-8)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95407","_score":1.0,"_source":{"id":95407,"goods_nomenclature_item_id":"2903999030","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"1,3-Dichlorobenzene
+        (CAS RN 541-73-1)","number_indents":4,"heading":{"goods_nomenclature_sid":36225,"goods_nomenclature_item_id":"2903000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Halogenated
+        derivatives of hydrocarbons","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90730","_score":1.0,"_source":{"id":90730,"goods_nomenclature_item_id":"2933998076","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"Manganese(2+),
-        bis(octahydro-1,4,7-trimethyl-1H-1,4,7-triazonine-N1,N4,N7)tri-\u03bc-oxodi-,
-        acetate (1:2)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97848","_score":1.0,"_source":{"id":97848,"goods_nomenclature_item_id":"2903999080","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"1-Bromo-3,4,5-trifluorobenzene
+        (CAS RN 138526-69-9)","number_indents":4,"heading":{"goods_nomenclature_sid":36225,"goods_nomenclature_item_id":"2903000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Halogenated
+        derivatives of hydrocarbons","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90514","_score":1.0,"_source":{"id":90514,"goods_nomenclature_item_id":"2933998082","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"Tolyltriazole
-        (CAS RN 29385-43-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92806","_score":1.0,"_source":{"id":92806,"goods_nomenclature_item_id":"2904100050","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"Sodium
+        2-methylprop-2-ene-1-sulphonate (CAS RN 1561-92-8)","number_indents":2,"heading":{"goods_nomenclature_sid":36312,"goods_nomenclature_item_id":"2904000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Sulphonated,
+        nitrated or nitrosated derivatives of hydrocarbons, whether or not halogenated","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90517","_score":1.0,"_source":{"id":90517,"goods_nomenclature_item_id":"2933998088","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"2,6-dichloroquinoxaline
-        (CAS RN 18671-97-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93106","_score":1.0,"_source":{"id":93106,"goods_nomenclature_item_id":"2904200030","producline_suffix":"80","validity_start_date":"2011-01-01T00:00:00+00:00","validity_end_date":null,"description":"1-Nitropropane
+        (CAS RN 108-03-2)","number_indents":2,"heading":{"goods_nomenclature_sid":36312,"goods_nomenclature_item_id":"2904000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Sulphonated,
+        nitrated or nitrosated derivatives of hydrocarbons, whether or not halogenated","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"94008","_score":1.0,"_source":{"id":94008,"goods_nomenclature_item_id":"2934208020","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"S-1,3-Benzothiazol-2-yl
-        (2Z)-(5-amino-1,2,4-thiadiazol-3-yl)(methoxyimino)ethanethioate (CAS RN 89604-91-1)","number_indents":3,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90316","_score":1.0,"_source":{"id":90316,"goods_nomenclature_item_id":"2904909520","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"1-Chloro-2,4-dinitrobenzene
+        (CAS RN 97-00-7)","number_indents":3,"heading":{"goods_nomenclature_sid":36312,"goods_nomenclature_item_id":"2904000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Sulphonated,
+        nitrated or nitrosated derivatives of hydrocarbons, whether or not halogenated","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"94009","_score":1.0,"_source":{"id":94009,"goods_nomenclature_item_id":"2934208030","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"2-[[(Z)-[1-(2-Amino-4-thiazolyl)-2-(2-benzothiazolylthio)-2-oxoethylidene]amino]oxy]-acetic
-        acid, methyl ester&nbsp;(CAS RN 246035-38-1)","number_indents":3,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"36342","_score":1.0,"_source":{"id":36342,"goods_nomenclature_item_id":"2905120000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Propan-1-ol
+        (propyl alcohol) and propan-2-ol (isopropyl alcohol)","number_indents":2,"heading":{"goods_nomenclature_sid":36339,"goods_nomenclature_item_id":"2905000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Acyclic
+        alcohols and their halogenated, sulphonated, nitrated or nitrosated derivatives","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90520","_score":1.0,"_source":{"id":90520,"goods_nomenclature_item_id":"2934996000","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"Chlorprothixene
-        (INN); thenalidine (INN) and its tartrates and maleates; furazolidone (INN);
-        7-aminocephalosporanic acid; salts and esters of (6R,7R)-3-acetoxymethyl-7-[(R)-2-formyloxy-2-phenylacetamido]-8-oxo-5-thia-1-azabicyclo[4.2.0]oct-2-ene-2-carboxylic
-        acid; 1-[2-(1,3-dioxan-2-yl)ethyl]-2-methylpyridinium bromide","number_indents":3,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"36343","_score":1.0,"_source":{"id":36343,"goods_nomenclature_item_id":"2905130000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Butan-1-ol
+        (n-butyl alcohol)","number_indents":2,"heading":{"goods_nomenclature_sid":36339,"goods_nomenclature_item_id":"2905000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Acyclic
+        alcohols and their halogenated, sulphonated, nitrated or nitrosated derivatives","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96855","_score":1.0,"_source":{"id":96855,"goods_nomenclature_item_id":"2934999014","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"Ethyl
-        N-{[1-methyl-2-({[4-(5-oxo-4,5-dihydro-1,2,4-oxadiazol-3-yl)phenyl]amino}methyl)-1H-benzimidazol-5-yl]carbonyl}-N-pyridin-2-yl-b-alaninate
-        (CAS RN 872728-84-2)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"36355","_score":1.0,"_source":{"id":36355,"goods_nomenclature_item_id":"2905170000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Dodecan-1-ol
+        (lauryl alcohol), hexadecan-1-ol (cetyl alcohol) and octadecan-1-ol (stearyl
+        alcohol)","number_indents":2,"heading":{"goods_nomenclature_sid":36339,"goods_nomenclature_item_id":"2905000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Acyclic
+        alcohols and their halogenated, sulphonated, nitrated or nitrosated derivatives","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"94010","_score":1.0,"_source":{"id":94010,"goods_nomenclature_item_id":"2934999017","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"Methyl(1,8-diethyl-1,3,4,9-tetrahydropyrano[3,4-b]indol-1-yl)acetate
-        (CAS RN 122188-02-7)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91414","_score":1.0,"_source":{"id":91414,"goods_nomenclature_item_id":"2905299010","producline_suffix":"80","validity_start_date":"2010-01-01T00:00:00+00:00","validity_end_date":null,"description":"3,5-Dimethylhex-1-yn-3-ol
+        (CAS RN 107-54-0)","number_indents":4,"heading":{"goods_nomenclature_sid":36339,"goods_nomenclature_item_id":"2905000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Acyclic
+        alcohols and their halogenated, sulphonated, nitrated or nitrosated derivatives","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96856","_score":1.0,"_source":{"id":96856,"goods_nomenclature_item_id":"2934999018","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"3,3-bis(2-Methyl-1-octyl-1H-indol-3-yl)phthalide
-        (CAS RN 50292-95-0)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92643","_score":1.0,"_source":{"id":92643,"goods_nomenclature_item_id":"2905299020","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"Dec-9-en-1-ol
+        (CAS RN 13019-22-2)","number_indents":4,"heading":{"goods_nomenclature_sid":36339,"goods_nomenclature_item_id":"2905000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Acyclic
+        alcohols and their halogenated, sulphonated, nitrated or nitrosated derivatives","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92679","_score":1.0,"_source":{"id":92679,"goods_nomenclature_item_id":"2934999020","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"Thiophene
-        (CAS RN 110-02-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96857","_score":1.0,"_source":{"id":96857,"goods_nomenclature_item_id":"2934999022","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"7-[4-(Diethylamino)-2-ethoxyphenyl]-7-(2-methyl-1-octyl-1H-indol-3-yl)
-        furo[3,4-b]pyridin-5(7H)-one (CAS RN 87563-89-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"94012","_score":1.0,"_source":{"id":94012,"goods_nomenclature_item_id":"2934999028","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"11-(Piperazin-1-yl)dibenzo[b,f][1,4]thiazepine
-        dihydrochloride&nbsp;(CAS RN 111974-74-4)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93148","_score":1.0,"_source":{"id":93148,"goods_nomenclature_item_id":"2934999040","producline_suffix":"80","validity_start_date":"2011-01-01T00:00:00+00:00","validity_end_date":null,"description":"2-Thiophene
-        ethylamine (CAS RN 30433-91-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96346","_score":1.0,"_source":{"id":96346,"goods_nomenclature_item_id":"2934999048","producline_suffix":"80","validity_start_date":"2012-07-01T00:00:00+00:00","validity_end_date":null,"description":"Propan-2-ol&nbsp;--&nbsp;2-methyl-4-(4-methylpiperazin-1-yl)-10H-thieno[2,3-b][1,5]benzodiazepine
-        (1:2) dihydrate, (CAS RN 864743-41-9)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93149","_score":1.0,"_source":{"id":93149,"goods_nomenclature_item_id":"2934999050","producline_suffix":"80","validity_start_date":"2011-01-01T00:00:00+00:00","validity_end_date":null,"description":"10-[1,1''-Biphenyl]-4-yl-2-(1-methylethyl)-9-oxo-9H-thioxanthenium
-        hexafluorophosphate (CAS RN 591773-92-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"80562","_score":1.0,"_source":{"id":80562,"goods_nomenclature_item_id":"2934999072","producline_suffix":"80","validity_start_date":"2004-07-01T00:00:00+00:00","validity_end_date":null,"description":"1-[3-(5-Nitro-2-furyl)allylideneamino]imidazolidine-2,4-dione
-        (CAS RN 1672-88-4)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"88776","_score":1.0,"_source":{"id":88776,"goods_nomenclature_item_id":"2934999074","producline_suffix":"80","validity_start_date":"2008-01-01T00:00:00+00:00","validity_end_date":null,"description":"2-Isopropylthioxanthone
-        (CAS RN 5495-84-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"86734","_score":1.0,"_source":{"id":86734,"goods_nomenclature_item_id":"2934999075","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"(4R-cis)-1,1-Dimethylethyl-6-[2[2-(4-fluorophenyl)-5-(1-isopropyl)-3-phenyl-4-[(phenylamino)carbonyl]-1H-pyrrol-1-yl]ethyl]-2,2-dimethyl-1,3-dioxane-4-acetate
-        (CAS RN 125971-95-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90736","_score":1.0,"_source":{"id":90736,"goods_nomenclature_item_id":"2934999079","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"Thiophen-2-ethanol
-        (CAS RN 5402-55-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91440","_score":1.0,"_source":{"id":91440,"goods_nomenclature_item_id":"2934999084","producline_suffix":"80","validity_start_date":"2010-01-01T00:00:00+00:00","validity_end_date":null,"description":"Etoxazole
-        (ISO) of a purity by weight of 94,8% or more (CAS RN 153233-91-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93696","_score":1.0,"_source":{"id":93696,"goods_nomenclature_item_id":"2934999085","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"N2-[1-(S)-Ethoxycarbonyl-3-phenylpropyl]-N6-trifluoroacetyl-L-lysyl-N2-carboxy
-        anhydride (CAS RN 126586-91-2)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90521","_score":1.0,"_source":{"id":90521,"goods_nomenclature_item_id":"2935003000","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"3-{1-[7-(Hexadecylsulphonylamino)-1H-indole-3-yl]-3-oxo-1H,3H-naphtho[1,8-cd]pyran-1-yl}-N,N-dimethyl-1H-indole-7-sulphonamide;
-        metosulam (ISO)","number_indents":1,"heading":{"goods_nomenclature_sid":37418,"goods_nomenclature_item_id":"2935000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Sulphonamides","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97881","_score":1.0,"_source":{"id":97881,"goods_nomenclature_item_id":"2935009017","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"6-Methyl-4-oxo-5,6-dihydro-4H-thieno[2,3-b]thiopyran-2-sulfonamide
-        (CAS RN 120279-88-1)","number_indents":2,"heading":{"goods_nomenclature_sid":37418,"goods_nomenclature_item_id":"2935000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Sulphonamides","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96347","_score":1.0,"_source":{"id":96347,"goods_nomenclature_item_id":"2935009048","producline_suffix":"80","validity_start_date":"2012-07-01T00:00:00+00:00","validity_end_date":null,"description":"(3R,5S,6E)-7-[4-(4-Fluorophenyl)-2-[methyl(methylsulfonyl)amino]-6-(propan-2-yl)pyrimidin-5-yl]-3,5-dihydroxyhept-6-enoic
-        acid&nbsp;--&nbsp;1-[(R)-(4-chlorophenyl)(phenyl)methyl]piperazine (1:1),
-        (CAS RN 1235588-99-4)","number_indents":2,"heading":{"goods_nomenclature_sid":37418,"goods_nomenclature_item_id":"2935000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Sulphonamides","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92681","_score":1.0,"_source":{"id":92681,"goods_nomenclature_item_id":"2935009077","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"[[4-[2-[[(3-Ethyl-2,5-dihydro-4-methyl-2-oxo-1H-pyrrol-1-yl)carbonyl]amino]
-        ethyl]phenyl]sulfonyl]-carbamic acid ethyl ester (CAS RN 318515-70-7)","number_indents":2,"heading":{"goods_nomenclature_sid":37418,"goods_nomenclature_item_id":"2935000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Sulphonamides","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"86740","_score":1.0,"_source":{"id":86740,"goods_nomenclature_item_id":"2935009089","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"3-(3-Bromo-6-fluoro-2-methylindol-1-ylsulphonyl)-N,N-dimethyl-1,2,4-triazol-1-sulphonamide
-        (CAS RN 348635-87-0)","number_indents":2,"heading":{"goods_nomenclature_sid":37418,"goods_nomenclature_item_id":"2935000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Sulphonamides","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"37437","_score":1.0,"_source":{"id":37437,"goods_nomenclature_item_id":"2936220000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Vitamin&nbsp;B<sub>1</sub>&nbsp;and
-        its derivatives","number_indents":2,"heading":{"goods_nomenclature_sid":37433,"goods_nomenclature_item_id":"2936000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Provitamins
-        and vitamins, natural or reproduced by synthesis (including natural concentrates),
-        derivatives thereof used primarily as vitamins, and intermixtures of the foregoing,
-        whether or not in any solvent","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"37444","_score":1.0,"_source":{"id":37444,"goods_nomenclature_item_id":"2936260000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Vitamin&nbsp;B<sub>1</sub><sub>2</sub>&nbsp;and
-        its derivatives","number_indents":2,"heading":{"goods_nomenclature_sid":37433,"goods_nomenclature_item_id":"2936000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Provitamins
-        and vitamins, natural or reproduced by synthesis (including natural concentrates),
-        derivatives thereof used primarily as vitamins, and intermixtures of the foregoing,
-        whether or not in any solvent","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93655","_score":1.0,"_source":{"id":93655,"goods_nomenclature_item_id":"2905299030","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"Dodeca-8,10-dien-1-ol
+        (CAS RN 33956-49-9)","number_indents":4,"heading":{"goods_nomenclature_sid":36339,"goods_nomenclature_item_id":"2905000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Acyclic
+        alcohols and their halogenated, sulphonated, nitrated or nitrosated derivatives","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
         allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93114","_score":1.0,"_source":{"id":93114,"goods_nomenclature_item_id":"2914500020","producline_suffix":"80","validity_start_date":"2011-01-01T00:00:00+00:00","validity_end_date":null,"description":"3''-Hydroxyacetophenone
         (CAS RN 121-71-1)","number_indents":2,"heading":{"goods_nomenclature_sid":36540,"goods_nomenclature_item_id":"2914000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Ketones
@@ -1031,305 +1181,29 @@ http_interactions:
         acid (CAS RN 88-63-1)","number_indents":5,"heading":{"goods_nomenclature_sid":36826,"goods_nomenclature_item_id":"2921000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Amine-function
         compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97938","_score":1.0,"_source":{"id":97938,"goods_nomenclature_item_id":"2927000085","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"C,C\u2019-Azodi(formamide)
-        (CAS RN 123-77-3) with:<br/>- a pH of 6,5 or more but not more than 7,5, and<br/>-
-        a semicarbazide (CAS RN 57-56-7) content of not more than 1 500 mg/kg as determined
-        by liquid chromatography mass spectrometry (LC-MS),<br/>- decomposition temperature
-        range of 195 \u00b0C - 205 \u00b0C,<br/>- specific gravity 1,64 \u2013 1,66,
-        and<br/>- combustion heat 215 - 220 Kcal/mol","number_indents":1,"heading":{"goods_nomenclature_sid":37029,"goods_nomenclature_item_id":"2927000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Diazo-,
-        azo- or azoxy-compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92656","_score":1.0,"_source":{"id":92656,"goods_nomenclature_item_id":"2922198540","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"2-(Dimethylamino)
+        ethyl benzoate (CAS RN 2208-05-1)","number_indents":4,"heading":{"goods_nomenclature_sid":36896,"goods_nomenclature_item_id":"2922000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Oxygen-function
+        amino-compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97965","_score":1.0,"_source":{"id":97965,"goods_nomenclature_item_id":"2928009055","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"Aminoguanidinium
-        hydrogen carbonate (CAS RN 2582-30-1)","number_indents":2,"heading":{"goods_nomenclature_sid":37033,"goods_nomenclature_item_id":"2928000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        derivatives of hydrazine or of hydroxylamine","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91599","_score":1.0,"_source":{"id":91599,"goods_nomenclature_item_id":"2922198570","producline_suffix":"80","validity_start_date":"2010-01-01T00:00:00+00:00","validity_end_date":null,"description":"D-(-)-threo-2-amino-1-(p-nitrophenyl)propane-1,3-diol
+        (CAS RN 716-61-0)","number_indents":4,"heading":{"goods_nomenclature_sid":36896,"goods_nomenclature_item_id":"2922000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Oxygen-function
+        amino-compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90479","_score":1.0,"_source":{"id":90479,"goods_nomenclature_item_id":"2929100080","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"1,3-Bis(isocyanatomethyl)
-        benzene (CAS RN 3634-83-1)","number_indents":2,"heading":{"goods_nomenclature_sid":37042,"goods_nomenclature_item_id":"2929000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Compounds
-        with other nitrogen function","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97950","_score":1.0,"_source":{"id":97950,"goods_nomenclature_item_id":"2922198585","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"(1S,4R)-cis-4-Amino-2-cyclopentene-1-methanol-D-tartrate
+        (CAS RN 229177-52-0)","number_indents":4,"heading":{"goods_nomenclature_sid":36896,"goods_nomenclature_item_id":"2922000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Oxygen-function
+        amino-compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93687","_score":1.0,"_source":{"id":93687,"goods_nomenclature_item_id":"2930909910","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"2,3-Bis((2-mercaptoethyl)thio)-1-propanethiol
-        (CAS RN 131538-00-6)","number_indents":3,"heading":{"goods_nomenclature_sid":37063,"goods_nomenclature_item_id":"2930000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Organo-sulphur
-        compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"73239","_score":1.0,"_source":{"id":73239,"goods_nomenclature_item_id":"2922390010","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+00:00","validity_end_date":null,"description":"1-Amino-4-bromo-9,10-dioxoanthracene-2-sulfonic
+        acid and its salts","number_indents":3,"heading":{"goods_nomenclature_sid":36896,"goods_nomenclature_item_id":"2922000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Oxygen-function
+        amino-compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96336","_score":1.0,"_source":{"id":96336,"goods_nomenclature_item_id":"2930909918","producline_suffix":"80","validity_start_date":"2012-07-01T00:00:00+00:00","validity_end_date":null,"description":"1-Methyl-5-[3-methyl-4-[4-[(trifluoromethyl)thio]phenoxy]phenyl]biuret,
-        (CAS RN 106310-17-2)","number_indents":3,"heading":{"goods_nomenclature_sid":37063,"goods_nomenclature_item_id":"2930000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Organo-sulphur
-        compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92657","_score":1.0,"_source":{"id":92657,"goods_nomenclature_item_id":"2922500020","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"1-[2-Amino-1-(4-methoxyphenyl)-ethyl]-cyclohexanol
+        hydrochloride (CAS RN 130198-05-9)","number_indents":2,"heading":{"goods_nomenclature_sid":36896,"goods_nomenclature_item_id":"2922000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Oxygen-function
+        amino-compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91609","_score":1.0,"_source":{"id":91609,"goods_nomenclature_item_id":"2930909940","producline_suffix":"80","validity_start_date":"2010-01-01T00:00:00+00:00","validity_end_date":null,"description":"3,3\u0384-Thiodi(propionic
-        acid) (CAS RN 111-17-1)","number_indents":3,"heading":{"goods_nomenclature_sid":37063,"goods_nomenclature_item_id":"2930000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Organo-sulphur
-        compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93136","_score":1.0,"_source":{"id":93136,"goods_nomenclature_item_id":"2930909950","producline_suffix":"80","validity_start_date":"2011-01-01T00:00:00+00:00","validity_end_date":null,"description":"[S-(R*,R*)]-2-Amino-1-[4-(methylthio)-phenyl]-1,3-propanediol
-        (CAS RN 23150-35-8)","number_indents":3,"heading":{"goods_nomenclature_sid":37063,"goods_nomenclature_item_id":"2930000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Organo-sulphur
-        compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97492","_score":1.0,"_source":{"id":97492,"goods_nomenclature_item_id":"2931909035","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"(Z)-Prop-1-en-1-ylphosphonic
-        acid (CAS RN 25383-06-6)","number_indents":3,"heading":{"goods_nomenclature_sid":37096,"goods_nomenclature_item_id":"2931000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        organo-inorganic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96256","_score":1.0,"_source":{"id":96256,"goods_nomenclature_item_id":"2931909075","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"Tetrakis(hydroxymethyl)phosphonium
-        chloride (CAS RN 124-64-1)","number_indents":3,"heading":{"goods_nomenclature_sid":37096,"goods_nomenclature_item_id":"2931000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        organo-inorganic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91131","_score":1.0,"_source":{"id":91131,"goods_nomenclature_item_id":"2932190041","producline_suffix":"80","validity_start_date":"2009-07-01T00:00:00+00:00","validity_end_date":null,"description":"2,2&nbsp;di(tetrahydrofuryl)propane
-        (CAS RN 89686-69-1)","number_indents":3,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95508","_score":1.0,"_source":{"id":95508,"goods_nomenclature_item_id":"2932201000","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"Phenolphthalein;
-        1-hydroxy-4-[1-(4-hydroxy-3-methoxycarbonyl-1-naphthyl)-3-oxo-1H,3H-benzo[de]isochromen-1-yl]-6-octadecyloxy-2-naphthoic
-        acid; 3\u2032-chloro-6\u2032-cyclohexylaminospiro[isobenzofuran-1(3H),9\u2032-xanthen]-3-one;
-        6\u2032-(N-ethyl-p-toluidino)-2\u2032-methylspiro[isobenzofuran-1(3H),9\u2032-xanthen]-3-one;
-        methyl-6-docosyloxy-1-hydroxy-4-[1-(4-hydroxy-3-methyl-1-phenanthryl)-3-oxo-1H,3H-naphtho[1,8-cd]pyran-1-yl]naphthalene-2-carboxylate","number_indents":2,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95512","_score":1.0,"_source":{"id":95512,"goods_nomenclature_item_id":"2932209010","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"2\u0384-Anilino-6\u0384-[ethyl(isopentyl)amino]-3\u0384-methylspiro[isobenzofuran
-        -1(3_H_),9\u0384-xanthen]-3-one","number_indents":3,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95513","_score":1.0,"_source":{"id":95513,"goods_nomenclature_item_id":"2932209035","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"6\u0384-Diethylamino-3\u0384-methyl-2\u0384-(2,4-xylidino)spiro[isobenzofuran
-        -1(3_H_),9\u0384-xanthen]-3-one","number_indents":3,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95558","_score":1.0,"_source":{"id":95558,"goods_nomenclature_item_id":"2932209060","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"6\u2019-(Diethylamino)-3\u2019-methyl-2\u2019-(phenylamino)-spiro[isobenzofuran-1(3H),9\u2019-[9H]xanthen]-3-one","number_indents":3,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95557","_score":1.0,"_source":{"id":95557,"goods_nomenclature_item_id":"2932209070","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"3\u2032,6\u2032-Bis(ethylamino)-2'',7''-dimethylspiro[isobenzofuran-1(3_H_),9''-
-        [9_H_]-xanthen]-3-one (CAS RN 41382-37-0)","number_indents":3,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95556","_score":1.0,"_source":{"id":95556,"goods_nomenclature_item_id":"2932209071","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"6\u2019-(Dibutylamino)-3\u2019-methyl-2\u2019-(phenylamino)-spiro[isobenzofuran-1(3H),9\u2019-[9H]xanthen]-3-one","number_indents":3,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95522","_score":1.0,"_source":{"id":95522,"goods_nomenclature_item_id":"2932209072","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"2\u2032-[Bis(phenylmethyl)amino]-6\u2032-(diethylamino)-spiro[isobenzofuran-1(3H),9\u2032-[9H]xanthen]-3-one","number_indents":3,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"59605","_score":1.0,"_source":{"id":59605,"goods_nomenclature_item_id":"2932920000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"1-(1,3-Benzodioxol-5-yl)propan-2-one","number_indents":2,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96338","_score":1.0,"_source":{"id":96338,"goods_nomenclature_item_id":"2932990020","producline_suffix":"80","validity_start_date":"2012-07-01T00:00:00+00:00","validity_end_date":null,"description":"Ethyl-2-methyl-1,3-dioxolane-2-acetate
-        (CAS RN 6413-10-1)","number_indents":3,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97493","_score":1.0,"_source":{"id":97493,"goods_nomenclature_item_id":"2932990025","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"1-(2,2-Difluorobenzo[d][1,3]dioxol-5-yl)cyclopropanecarboxylic
-        acid (CAS RN 862574-88-7)","number_indents":3,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97944","_score":1.0,"_source":{"id":97944,"goods_nomenclature_item_id":"2932990055","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"6-Fluoro-3,4-dihydro-2H-1-benzopyran-2-carboxylic
-        acid (CAS RN 99199-60-7)","number_indents":3,"heading":{"goods_nomenclature_sid":37122,"goods_nomenclature_item_id":"2932000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with oxygen hetero-atom(s) only","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"81614","_score":1.0,"_source":{"id":81614,"goods_nomenclature_item_id":"2933199030","producline_suffix":"80","validity_start_date":"2005-07-01T00:00:00+00:00","validity_end_date":null,"description":"3-methyl-1-p-tolyl-5-pyrazolone
-        (CAS RN 86-92-0)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90724","_score":1.0,"_source":{"id":90724,"goods_nomenclature_item_id":"2933199070","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"4,5-Diamino-1-(2-hydroxyethyl)-pyrazolsulphate
-        (CAS RN 155601-30-2)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96841","_score":1.0,"_source":{"id":96841,"goods_nomenclature_item_id":"2933199080","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"3-(4,5-Dihydro-3-methyl-5-oxo-1H-pyrazol-1-yl)benzenesulphonic
-        acid (CAS RN 119-17-5)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97494","_score":1.0,"_source":{"id":97494,"goods_nomenclature_item_id":"2933199085","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"Allyl
-        5-amino-4-(2-methylphenyl)-3-oxo-2,3-dihydro-1H-1-pyrazolcarbothioat (CAS
-        RN 473799-16-5)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"86726","_score":1.0,"_source":{"id":86726,"goods_nomenclature_item_id":"2933210050","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"1-Bromo-3-chloro-5,5-dimethylhydantoin
-        (CAS RN 16079-88-2)","number_indents":3,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"88367","_score":1.0,"_source":{"id":88367,"goods_nomenclature_item_id":"2933210070","producline_suffix":"80","validity_start_date":"2007-07-01T00:00:00+00:00","validity_end_date":null,"description":"\u03b1-(4-Methoxybenzoyl)-\u03b1-(1-benzyl-5-ethoxy-3-hydantoinyl)-2-chloro-5-dodecyloxycarbonylacetanilide
-        (CAS RN 70950-45-7)","number_indents":3,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97876","_score":1.0,"_source":{"id":97876,"goods_nomenclature_item_id":"2933299015","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"Ethyl
-        4-(1-hydroxy-1-methylethyl)-2-propylimidazole-5-carboxylate (CAS RN 144689-93-0)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97878","_score":1.0,"_source":{"id":97878,"goods_nomenclature_item_id":"2933299035","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"1-Trityl-4-formylimidazole&nbsp;(CAS
-        RN 33016-47-6)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"57465","_score":1.0,"_source":{"id":57465,"goods_nomenclature_item_id":"2933299040","producline_suffix":"80","validity_start_date":"1995-01-01T00:00:00+00:00","validity_end_date":null,"description":"Triflumizole
-        (ISO) (CAS RN 68694-11-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97968","_score":1.0,"_source":{"id":97968,"goods_nomenclature_item_id":"2933299045","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prochloraz
-        copper chloride (ISO) (CAS RN 156065-03-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93973","_score":1.0,"_source":{"id":93973,"goods_nomenclature_item_id":"2933299060","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"1-Cyano-2-methyl-1-[2-(5-methylimidazol-4-ylmethylthio)ethyl]isothiourea&nbsp;(CAS
-        RN 52378-40-2)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93976","_score":1.0,"_source":{"id":93976,"goods_nomenclature_item_id":"2933399937","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"Aqueous
-        solution of pyridine-2-thiol-1-oxide, sodium salt&nbsp;(CAS RN 3811-73-2)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"81615","_score":1.0,"_source":{"id":81615,"goods_nomenclature_item_id":"2933399940","producline_suffix":"80","validity_start_date":"2005-07-01T00:00:00+00:00","validity_end_date":null,"description":"2-chloropyridine
-        (CAS RN 109-09-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93975","_score":1.0,"_source":{"id":93975,"goods_nomenclature_item_id":"2933399942","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"2,2,6,6-Tetramethylpiperidine&nbsp;(CAS
-        RN 768-66-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97879","_score":1.0,"_source":{"id":97879,"goods_nomenclature_item_id":"2933399953","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"3-Bromopyridine
-        (CAS RN 626-55-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91435","_score":1.0,"_source":{"id":91435,"goods_nomenclature_item_id":"2933399955","producline_suffix":"80","validity_start_date":"2010-01-01T00:00:00+00:00","validity_end_date":null,"description":"Pyriproxyfen
-        (ISO) of a purity by weight of 97% or more (CAS RN 95737-68-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96341","_score":1.0,"_source":{"id":96341,"goods_nomenclature_item_id":"2933399972","producline_suffix":"80","validity_start_date":"2012-07-01T00:00:00+00:00","validity_end_date":null,"description":"5,6-Dimethoxy-2-[(4-piperidinyl)methyl]indan-1-one,
-        (CAS RN 120014-30-4)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
-        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95245","_score":1.0,"_source":{"id":95245,"goods_nomenclature_item_id":"2710196400","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
-        a sulphur content exceeding 0,1% by weight but not exceeding 1% by weight","number_indents":6,"heading":{"goods_nomenclature_sid":35586,"goods_nomenclature_item_id":"2710000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Petroleum
-        oils and oils obtained from bituminous minerals, other than crude; preparations
-        not elsewhere specified or included, containing by weight 70% or more of petroleum
-        oils or of oils obtained from bituminous minerals, these oils being the basic
-        constituents of the preparations","number_indents":0},"chapter":{"goods_nomenclature_sid":35521,"goods_nomenclature_item_id":"2700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Mineral
-        fuels, mineral oils and products of their distillation; bituminous substances;
-        mineral waxes"},"section":{"numeral":"V","title":"Mineral products","position":5}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95246","_score":1.0,"_source":{"id":95246,"goods_nomenclature_item_id":"2710196800","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
-        a sulphur content exceeding 1% by weight","number_indents":6,"heading":{"goods_nomenclature_sid":35586,"goods_nomenclature_item_id":"2710000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Petroleum
-        oils and oils obtained from bituminous minerals, other than crude; preparations
-        not elsewhere specified or included, containing by weight 70% or more of petroleum
-        oils or of oils obtained from bituminous minerals, these oils being the basic
-        constituents of the preparations","number_indents":0},"chapter":{"goods_nomenclature_sid":35521,"goods_nomenclature_item_id":"2700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Mineral
-        fuels, mineral oils and products of their distillation; bituminous substances;
-        mineral waxes"},"section":{"numeral":"V","title":"Mineral products","position":5}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95256","_score":1.0,"_source":{"id":95256,"goods_nomenclature_item_id":"2710203500","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
-        a sulphur content exceeding 0,1% by weight but not exceeding 1% by weight","number_indents":3,"heading":{"goods_nomenclature_sid":35586,"goods_nomenclature_item_id":"2710000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Petroleum
-        oils and oils obtained from bituminous minerals, other than crude; preparations
-        not elsewhere specified or included, containing by weight 70% or more of petroleum
-        oils or of oils obtained from bituminous minerals, these oils being the basic
-        constituents of the preparations","number_indents":0},"chapter":{"goods_nomenclature_sid":35521,"goods_nomenclature_item_id":"2700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Mineral
-        fuels, mineral oils and products of their distillation; bituminous substances;
-        mineral waxes"},"section":{"numeral":"V","title":"Mineral products","position":5}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95257","_score":1.0,"_source":{"id":95257,"goods_nomenclature_item_id":"2710203900","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
-        a sulphur content exceeding 1% by weight","number_indents":3,"heading":{"goods_nomenclature_sid":35586,"goods_nomenclature_item_id":"2710000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Petroleum
-        oils and oils obtained from bituminous minerals, other than crude; preparations
-        not elsewhere specified or included, containing by weight 70% or more of petroleum
-        oils or of oils obtained from bituminous minerals, these oils being the basic
-        constituents of the preparations","number_indents":0},"chapter":{"goods_nomenclature_sid":35521,"goods_nomenclature_item_id":"2700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Mineral
-        fuels, mineral oils and products of their distillation; bituminous substances;
-        mineral waxes"},"section":{"numeral":"V","title":"Mineral products","position":5}}},{"_index":"tariff-commodities","_type":"commodity","_id":"64989","_score":1.0,"_source":{"id":64989,"goods_nomenclature_item_id":"2712201000","producline_suffix":"80","validity_start_date":"1997-01-01T00:00:00+00:00","validity_end_date":null,"description":"Synthetic
-        paraffin wax of a molecular weight of 460&nbsp;or more but not exceeding 1&nbsp;560","number_indents":2,"heading":{"goods_nomenclature_sid":35685,"goods_nomenclature_item_id":"2712000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Petroleum
-        jelly; paraffin wax, microcrystalline petroleum wax, slack wax, ozokerite,
-        lignite wax, peat wax, other mineral waxes, and similar products obtained
-        by synthesis or by other processes, whether or not coloured","number_indents":0},"chapter":{"goods_nomenclature_sid":35521,"goods_nomenclature_item_id":"2700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Mineral
-        fuels, mineral oils and products of their distillation; bituminous substances;
-        mineral waxes"},"section":{"numeral":"V","title":"Mineral products","position":5}}},{"_index":"tariff-commodities","_type":"commodity","_id":"64992","_score":1.0,"_source":{"id":64992,"goods_nomenclature_item_id":"2712909100","producline_suffix":"80","validity_start_date":"1997-01-01T00:00:00+00:00","validity_end_date":null,"description":"Blend
-        of 1-alkenes containing by weight 80% or more of 1-alkenes of a chain-length
-        of 24&nbsp;carbon atoms or more but not exceeding 28&nbsp;carbon atoms","number_indents":4,"heading":{"goods_nomenclature_sid":35685,"goods_nomenclature_item_id":"2712000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Petroleum
-        jelly; paraffin wax, microcrystalline petroleum wax, slack wax, ozokerite,
-        lignite wax, peat wax, other mineral waxes, and similar products obtained
-        by synthesis or by other processes, whether or not coloured","number_indents":0},"chapter":{"goods_nomenclature_sid":35521,"goods_nomenclature_item_id":"2700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Mineral
-        fuels, mineral oils and products of their distillation; bituminous substances;
-        mineral waxes"},"section":{"numeral":"V","title":"Mineral products","position":5}}},{"_index":"tariff-commodities","_type":"commodity","_id":"64994","_score":1.0,"_source":{"id":64994,"goods_nomenclature_item_id":"2712909910","producline_suffix":"80","validity_start_date":"1997-01-01T00:00:00+00:00","validity_end_date":"2014-06-30T00:00:00+00:00","description":"Blend
-        of 1-alkenes containing 80% by weight or more of 1-alkenes of a chain-length
-        of 20 and 22 carbon atoms","number_indents":5,"heading":{"goods_nomenclature_sid":35685,"goods_nomenclature_item_id":"2712000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Petroleum
-        jelly; paraffin wax, microcrystalline petroleum wax, slack wax, ozokerite,
-        lignite wax, peat wax, other mineral waxes, and similar products obtained
-        by synthesis or by other processes, whether or not coloured","number_indents":0},"chapter":{"goods_nomenclature_sid":35521,"goods_nomenclature_item_id":"2700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Mineral
-        fuels, mineral oils and products of their distillation; bituminous substances;
-        mineral waxes"},"section":{"numeral":"V","title":"Mineral products","position":5}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97468","_score":1.0,"_source":{"id":97468,"goods_nomenclature_item_id":"2811198030","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"Phosphorous
-        acid (CAS RN 10294-56-1)/phosphonic acid (CAS RN 13598-36-2) used as an ingredient
-        for production of additives used in poly(vinyl chloride) industry","number_indents":4,"heading":{"goods_nomenclature_sid":35783,"goods_nomenclature_item_id":"2811000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        inorganic acids and other inorganic oxygen compounds of non-metals","number_indents":0},"chapter":{"goods_nomenclature_sid":35719,"goods_nomenclature_item_id":"2800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Inorganic
-        chemicals; organic or inorganic compounds of precious metals, of rare-earth
-        metals, of radioactive elements or of isotopes"},"section":{"numeral":"VI","title":"Products
-        of the chemical or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"88344","_score":1.0,"_source":{"id":88344,"goods_nomenclature_item_id":"2811220020","producline_suffix":"80","validity_start_date":"2007-07-01T00:00:00+00:00","validity_end_date":"2014-06-30T00:00:00+00:00","description":"Microspheres
-        of amorphous silicon of a particle size of 5&nbsp;\u03bcm (\u00b1 1&nbsp;\u00b5m),
-        for use in the manufacture of cosmetic products","number_indents":3,"heading":{"goods_nomenclature_sid":35783,"goods_nomenclature_item_id":"2811000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        inorganic acids and other inorganic oxygen compounds of non-metals","number_indents":0},"chapter":{"goods_nomenclature_sid":35719,"goods_nomenclature_item_id":"2800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Inorganic
-        chemicals; organic or inorganic compounds of precious metals, of rare-earth
-        metals, of radioactive elements or of isotopes"},"section":{"numeral":"VI","title":"Products
-        of the chemical or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"88345","_score":1.0,"_source":{"id":88345,"goods_nomenclature_item_id":"2811220030","producline_suffix":"80","validity_start_date":"2007-07-01T00:00:00+00:00","validity_end_date":null,"description":"Balls
-        of porous white silica of a particle size of more than 1&nbsp;\u00b5m for
-        use in the manufacture of cosmetic products","number_indents":3,"heading":{"goods_nomenclature_sid":35783,"goods_nomenclature_item_id":"2811000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        inorganic acids and other inorganic oxygen compounds of non-metals","number_indents":0},"chapter":{"goods_nomenclature_sid":35719,"goods_nomenclature_item_id":"2800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Inorganic
-        chemicals; organic or inorganic compounds of precious metals, of rare-earth
-        metals, of radioactive elements or of isotopes"},"section":{"numeral":"VI","title":"Products
-        of the chemical or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93650","_score":1.0,"_source":{"id":93650,"goods_nomenclature_item_id":"2818109110","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"Sintered
-        corundum with micro crystalline structure, containing by weight: <br/>-&nbsp;94%
-        or more, but not more than 98,5% of \u03b1-Al<sub>2</sub>O<sub>3</sub>, <br/>-&nbsp;2%
-        (\u00b1 1,5%) of magnesium spinel, <br/>-&nbsp;1% (\u00b1 0,6%) of yttrium
-        oxide and <br/>-&nbsp;2%&nbsp;(\u00b1 1,2%) of each lanthanum oxide and neodymium
-        oxide <br/>with less than 50% of the total weight having a particle size of
-        more than 10&nbsp;mm","number_indents":4,"heading":{"goods_nomenclature_sid":35831,"goods_nomenclature_item_id":"2818000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
-        oxide (including artificial corundum); aluminium hydroxide","number_indents":0},"chapter":{"goods_nomenclature_sid":35719,"goods_nomenclature_item_id":"2800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Inorganic
-        chemicals; organic or inorganic compounds of precious metals, of rare-earth
-        metals, of radioactive elements or of isotopes"},"section":{"numeral":"VI","title":"Products
-        of the chemical or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96862","_score":1.0,"_source":{"id":96862,"goods_nomenclature_item_id":"2825100010","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"Hydroxylammonium
-        chloride (CAS RN 5470-11-1)","number_indents":2,"heading":{"goods_nomenclature_sid":35856,"goods_nomenclature_item_id":"2825000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Hydrazine
-        and hydroxylamine and their inorganic salts; other inorganic bases; other
-        metal oxides, hydroxides and peroxides","number_indents":0},"chapter":{"goods_nomenclature_sid":35719,"goods_nomenclature_item_id":"2800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Inorganic
-        chemicals; organic or inorganic compounds of precious metals, of rare-earth
-        metals, of radioactive elements or of isotopes"},"section":{"numeral":"VI","title":"Products
-        of the chemical or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"65007","_score":1.0,"_source":{"id":65007,"goods_nomenclature_item_id":"2825901100","producline_suffix":"80","validity_start_date":"1997-01-01T00:00:00+00:00","validity_end_date":null,"description":"Calcium
-        hydroxide of a purity of 98% or more calculated on the dry weight, in the
-        form of particles of which:-&nbsp;not more than 1% by weight have a particle-size
-        exceeding 75&nbsp;micrometres and-&nbsp;not more than 4% by weight have a
-        particle-size of less than 1,3&nbsp;micrometres","number_indents":3,"heading":{"goods_nomenclature_sid":35856,"goods_nomenclature_item_id":"2825000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Hydrazine
-        and hydroxylamine and their inorganic salts; other inorganic bases; other
-        metal oxides, hydroxides and peroxides","number_indents":0},"chapter":{"goods_nomenclature_sid":35719,"goods_nomenclature_item_id":"2800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Inorganic
-        chemicals; organic or inorganic compounds of precious metals, of rare-earth
-        metals, of radioactive elements or of isotopes"},"section":{"numeral":"VI","title":"Products
-        of the chemical or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96418","_score":1.0,"_source":{"id":96418,"goods_nomenclature_item_id":"2903730010","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":"2014-06-30T00:00:00+00:00","description":"1,1-Dichloro-1-fluoroethane
-        (HCFC-141b)","number_indents":3,"heading":{"goods_nomenclature_sid":36225,"goods_nomenclature_item_id":"2903000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Halogenated
-        derivatives of hydrocarbons","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95391","_score":1.0,"_source":{"id":95391,"goods_nomenclature_item_id":"2903899010","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"1,6,7,8,9,14,15,16,17,17,18,18-Dodecachloropentacyclo[12.2.1.1<sup>6</sup><sup>,</sup><sup>9</sup>.0<sup>2</sup><sup>,</sup><sup>1</sup><sup>3</sup>.0<sup>5</sup><sup>,</sup><sup>1</sup><sup>0</sup>]octadeca-7,15-diene,
-        (CAS RN 13560-89-9)","number_indents":4,"heading":{"goods_nomenclature_sid":36225,"goods_nomenclature_item_id":"2903000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Halogenated
-        derivatives of hydrocarbons","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95407","_score":1.0,"_source":{"id":95407,"goods_nomenclature_item_id":"2903999030","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"1,3-Dichlorobenzene
-        (CAS RN 541-73-1)","number_indents":4,"heading":{"goods_nomenclature_sid":36225,"goods_nomenclature_item_id":"2903000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Halogenated
-        derivatives of hydrocarbons","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97848","_score":1.0,"_source":{"id":97848,"goods_nomenclature_item_id":"2903999080","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"1-Bromo-3,4,5-trifluorobenzene
-        (CAS RN 138526-69-9)","number_indents":4,"heading":{"goods_nomenclature_sid":36225,"goods_nomenclature_item_id":"2903000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Halogenated
-        derivatives of hydrocarbons","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92806","_score":1.0,"_source":{"id":92806,"goods_nomenclature_item_id":"2904100050","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"Sodium
-        2-methylprop-2-ene-1-sulphonate (CAS RN 1561-92-8)","number_indents":2,"heading":{"goods_nomenclature_sid":36312,"goods_nomenclature_item_id":"2904000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Sulphonated,
-        nitrated or nitrosated derivatives of hydrocarbons, whether or not halogenated","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93106","_score":1.0,"_source":{"id":93106,"goods_nomenclature_item_id":"2904200030","producline_suffix":"80","validity_start_date":"2011-01-01T00:00:00+00:00","validity_end_date":null,"description":"1-Nitropropane
-        (CAS RN 108-03-2)","number_indents":2,"heading":{"goods_nomenclature_sid":36312,"goods_nomenclature_item_id":"2904000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Sulphonated,
-        nitrated or nitrosated derivatives of hydrocarbons, whether or not halogenated","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90316","_score":1.0,"_source":{"id":90316,"goods_nomenclature_item_id":"2904909520","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"1-Chloro-2,4-dinitrobenzene
-        (CAS RN 97-00-7)","number_indents":3,"heading":{"goods_nomenclature_sid":36312,"goods_nomenclature_item_id":"2904000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Sulphonated,
-        nitrated or nitrosated derivatives of hydrocarbons, whether or not halogenated","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"36342","_score":1.0,"_source":{"id":36342,"goods_nomenclature_item_id":"2905120000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Propan-1-ol
-        (propyl alcohol) and propan-2-ol (isopropyl alcohol)","number_indents":2,"heading":{"goods_nomenclature_sid":36339,"goods_nomenclature_item_id":"2905000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Acyclic
-        alcohols and their halogenated, sulphonated, nitrated or nitrosated derivatives","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"36343","_score":1.0,"_source":{"id":36343,"goods_nomenclature_item_id":"2905130000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Butan-1-ol
-        (n-butyl alcohol)","number_indents":2,"heading":{"goods_nomenclature_sid":36339,"goods_nomenclature_item_id":"2905000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Acyclic
-        alcohols and their halogenated, sulphonated, nitrated or nitrosated derivatives","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"36355","_score":1.0,"_source":{"id":36355,"goods_nomenclature_item_id":"2905170000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Dodecan-1-ol
-        (lauryl alcohol), hexadecan-1-ol (cetyl alcohol) and octadecan-1-ol (stearyl
-        alcohol)","number_indents":2,"heading":{"goods_nomenclature_sid":36339,"goods_nomenclature_item_id":"2905000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Acyclic
-        alcohols and their halogenated, sulphonated, nitrated or nitrosated derivatives","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91414","_score":1.0,"_source":{"id":91414,"goods_nomenclature_item_id":"2905299010","producline_suffix":"80","validity_start_date":"2010-01-01T00:00:00+00:00","validity_end_date":null,"description":"3,5-Dimethylhex-1-yn-3-ol
-        (CAS RN 107-54-0)","number_indents":4,"heading":{"goods_nomenclature_sid":36339,"goods_nomenclature_item_id":"2905000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Acyclic
-        alcohols and their halogenated, sulphonated, nitrated or nitrosated derivatives","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92643","_score":1.0,"_source":{"id":92643,"goods_nomenclature_item_id":"2905299020","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"Dec-9-en-1-ol
-        (CAS RN 13019-22-2)","number_indents":4,"heading":{"goods_nomenclature_sid":36339,"goods_nomenclature_item_id":"2905000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Acyclic
-        alcohols and their halogenated, sulphonated, nitrated or nitrosated derivatives","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93655","_score":1.0,"_source":{"id":93655,"goods_nomenclature_item_id":"2905299030","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"Dodeca-8,10-dien-1-ol
-        (CAS RN 33956-49-9)","number_indents":4,"heading":{"goods_nomenclature_sid":36339,"goods_nomenclature_item_id":"2905000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Acyclic
-        alcohols and their halogenated, sulphonated, nitrated or nitrosated derivatives","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"76735","_score":1.0,"_source":{"id":76735,"goods_nomenclature_item_id":"2922500070","producline_suffix":"80","validity_start_date":"2003-07-01T00:00:00+00:00","validity_end_date":null,"description":"2-(1-Hydroxycyclohexyl)-2-(4-methoxyphenyl)ethylammonium
+        acetate","number_indents":2,"heading":{"goods_nomenclature_sid":36896,"goods_nomenclature_item_id":"2922000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Oxygen-function
+        amino-compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
         allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"81600","_score":1.0,"_source":{"id":81600,"goods_nomenclature_item_id":"2906290020","producline_suffix":"80","validity_start_date":"2005-07-01T00:00:00+00:00","validity_end_date":null,"description":"1-Hydroxymethyl-4-methyl-2,3,5,6-tetrafluorobenzene
         (CAS RN 79538-03-7)","number_indents":3,"heading":{"goods_nomenclature_sid":36399,"goods_nomenclature_item_id":"2906000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Cyclic
@@ -1372,67 +1246,221 @@ http_interactions:
         and quinones, whether or not with other oxygen function, and their halogenated,
         sulphonated, nitrated or nitrosated derivatives","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
         chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"67104","_score":1.0,"_source":{"id":67104,"goods_nomenclature_item_id":"2846100010","producline_suffix":"80","validity_start_date":"1997-07-01T00:00:00+00:00","validity_end_date":null,"description":"Rare-earth
-        concentrate containing by weight 60% or more but not more than 75% of rare-earth
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93712","_score":1.0,"_source":{"id":93712,"goods_nomenclature_item_id":"3808939040","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"Mixed
+        white powder containing by weight: <br/>-&nbsp;3% or more but not more than
+        3,6% of 1-methylcyclopropene with a purity more than 96% and <br/>-&nbsp;containing
+        less than 0,05% of each impurity of 1-chloro-2-methylpropene and 3-chloro-2-methylpropene
+        <br/>for use in the manufacture of a growth regulator of post-harvest fruits,
+        vegetables and ornamentals with a specific generator","number_indents":4,"heading":{"goods_nomenclature_sid":38368,"goods_nomenclature_item_id":"3808000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insecticides,
+        rodenticides, fungicides, herbicides, anti-sprouting products and plant-growth
+        regulators, disinfectants and similar products, put up in forms or packings
+        for retail sale or as preparations or articles (for example, sulphur-treated
+        bands, wicks and candles, and fly-papers)","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93713","_score":1.0,"_source":{"id":93713,"goods_nomenclature_item_id":"3808939050","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"Preparation
+        in the form of powder, containing by weight: <br/>-&nbsp;55% or more of Gibberellin
+        A4, <br/>-&nbsp;1% or more but not more than 35% of Gibberellin A7, <br/>-&nbsp;90%
+        or more of Gibberellin A4&nbsp;and Gibberellin A7&nbsp;combined <br/>-&nbsp;not
+        more than 10% of a combination of water and other naturally occurring Gibberellins
+        <br/>of a kind used in plant growth regulators","number_indents":4,"heading":{"goods_nomenclature_sid":38368,"goods_nomenclature_item_id":"3808000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insecticides,
+        rodenticides, fungicides, herbicides, anti-sprouting products and plant-growth
+        regulators, disinfectants and similar products, put up in forms or packings
+        for retail sale or as preparations or articles (for example, sulphur-treated
+        bands, wicks and candles, and fly-papers)","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96890","_score":1.0,"_source":{"id":96890,"goods_nomenclature_item_id":"3811290040","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"Additives
+        for lubricating oils, consisting of reaction products of 2-methyl-prop-1-ene&nbsp;
+        with sulphur monochloride and sodium sulphide (CAS RN 68511-50-2), with a
+        chlorine content by weight of 0,05% or more but not more than&nbsp; 0,5%,
+        used as a concentrated additive for the manufacture of engine oils through
+        a blending process","number_indents":3,"heading":{"goods_nomenclature_sid":38428,"goods_nomenclature_item_id":"3811000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Anti-knock
+        preparations, oxidation inhibitors, gum inhibitors, viscosity improvers, anti-corrosive
+        preparations and other prepared additives, for mineral oils (including gasoline)
+        or for other liquids used for the same purposes as mineral oils","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"65223","_score":1.0,"_source":{"id":65223,"goods_nomenclature_item_id":"3812201000","producline_suffix":"80","validity_start_date":"1997-01-01T00:00:00+00:00","validity_end_date":null,"description":"Reaction
+        mixture containing benzyl 3-isobutyryloxy-1-isopropyl-2,2-dimethylpropyl phthalate
+        and benzyl 3-isobutyryloxy-2,2,4-trimethylpentyl phthalate","number_indents":2,"heading":{"goods_nomenclature_sid":38440,"goods_nomenclature_item_id":"3812000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
+        rubber accelerators; compound plasticisers for rubber or plastics, not elsewhere
+        specified or included; anti-oxidising preparations and other compound stabilisers
+        for rubber or plastics","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"58617","_score":1.0,"_source":{"id":58617,"goods_nomenclature_item_id":"3812308020","producline_suffix":"80","validity_start_date":"1995-07-01T00:00:00+00:00","validity_end_date":null,"description":"Mixture
+        containing predominantly bis(2,2,6,6-tetramethyl-1-octyloxy-4-piperidyl) sebacate","number_indents":3,"heading":{"goods_nomenclature_sid":38440,"goods_nomenclature_item_id":"3812000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
+        rubber accelerators; compound plasticisers for rubber or plastics, not elsewhere
+        specified or included; anti-oxidising preparations and other compound stabilisers
+        for rubber or plastics","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"98109","_score":1.0,"_source":{"id":98109,"goods_nomenclature_item_id":"3812308025","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"UV&nbsp;photo
+        stabiliser containing:<br/>-&nbsp;\u03b1-[3-[3-(2H-Benzotriazol-2-yl)-5-(1,1-dimethylethyl)-4-hydroxyphenyl]-1-oxopropyl]-\u03c9-hydroxypoly(oxy-1,2-ethanediyl)
+        (CAS RN 104810-48-2); &nbsp;<br/>-&nbsp;\u03b1-[3-[3-(2H-Benzotriazol-2-yl)-5-(1,1-dimethylethyl)-4-hydroxyphenyl]-1-oxopropyl]-\u03c9-[3-[3-(2H-benzotriazol-2-yl)-5-(1,1-dimethylethyl)-4-hydroxyphenyl]-1-oxopropoxy]poly
+        (oxy-1,2-ethanediyl) (CAS RN 104810-47-1);&nbsp;<br/>-&nbsp;polyethylene glycol
+        of a weight average molecular weight (Mw) of 300&nbsp;(CAS RN 25322-68-3)<br/>-&nbsp;bis
+        (1,2,2,6,6-pentamethyl-4-piperidyl)sebacate (CAS RN 41556-26-7), and<br/>-&nbsp;methyl-1,2,2,6,6-pentamethyl-4-
+        piperidyl sebacate (CAS RN 82919-37-7)","number_indents":3,"heading":{"goods_nomenclature_sid":38440,"goods_nomenclature_item_id":"3812000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
+        rubber accelerators; compound plasticisers for rubber or plastics, not elsewhere
+        specified or included; anti-oxidising preparations and other compound stabilisers
+        for rubber or plastics","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96279","_score":1.0,"_source":{"id":96279,"goods_nomenclature_item_id":"3812308065","producline_suffix":"80","validity_start_date":"2012-07-01T00:00:00+00:00","validity_end_date":null,"description":"Stabiliser
+        for plastic material containing: <br/>\t\t\t\t\t\t<br/>-&nbsp;2-ethylhexyl
+        10-ethyl-4,4-dimethyl-7-oxo-8-oxa-3,5-dithia-4-stannatetradecanoate (CAS&nbsp;RN&nbsp;57583-35-4),
+        <br/>\t\t\t\t\t\t<br/>-&nbsp;2-ethylhexyl 10-ethyl-4-[[2-[(2-ethylhexyl)oxy]-2-oxoethyl]thio]-4-methyl-7-oxo-8-oxa-3,5-dithia-4-stannatetradecanoate
+        (CAS&nbsp;RN&nbsp;57583-34-3), and <br/>\t\t\t\t\t\t<br/>-&nbsp;2-ethylhexyl
+        mercaptoacetate (CAS RN 7659-86-1)","number_indents":3,"heading":{"goods_nomenclature_sid":38440,"goods_nomenclature_item_id":"3812000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
+        rubber accelerators; compound plasticisers for rubber or plastics, not elsewhere
+        specified or included; anti-oxidising preparations and other compound stabilisers
+        for rubber or plastics","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96281","_score":1.0,"_source":{"id":96281,"goods_nomenclature_item_id":"3812308070","producline_suffix":"80","validity_start_date":"2012-07-01T00:00:00+00:00","validity_end_date":null,"description":"Light
+        stabiliser containing: <br/>\t\t\t\t\t\t<br/>-&nbsp;branched and linear alkyl
+        esters of 3-(2H-benzotriazolyl)-5-(1,1-dimethylethyl)-4-hydroxybenzenepropanoic
+        acid (CAS&nbsp;RN&nbsp;127519-17-9), and <br/>\t\t\t\t\t\t<br/>-&nbsp;1-methoxy-2-propyl
+        acetate (CAS RN 108-65-6)","number_indents":3,"heading":{"goods_nomenclature_sid":38440,"goods_nomenclature_item_id":"3812000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
+        rubber accelerators; compound plasticisers for rubber or plastics, not elsewhere
+        specified or included; anti-oxidising preparations and other compound stabilisers
+        for rubber or plastics","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"80582","_score":1.0,"_source":{"id":80582,"goods_nomenclature_item_id":"3814009020","producline_suffix":"80","validity_start_date":"2004-07-01T00:00:00+00:00","validity_end_date":null,"description":"Mixture
+        containing by weight:<br/>- 69% or more but not more than 71% of 1-methoxypropan-2-ol,<br/>-
+        29% or more but not more than 31% of 2-methoxy-1-methylethyl acetate","number_indents":2,"heading":{"goods_nomenclature_sid":38461,"goods_nomenclature_item_id":"3814000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        composite solvents and thinners, not elsewhere specified or included; prepared
+        paint or varnish removers","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96894","_score":1.0,"_source":{"id":96894,"goods_nomenclature_item_id":"3815909018","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"Oxidation
+        catalyst with an active ingredient of di[manganese (1+)], 1,2-bis(octahydro-4,7-dimethyl-1H-1,4,7-triazonine-1-yl-kN<sup>1</sup>,
+        kN<sup>4</sup>, kN<sup>7</sup>)ethane-di-\u03bc-oxo-\u03bc-(ethanoato-kO,
+        kO'')-, di[chloride(1-)], used to accelerate chemical oxidation or bleaching
+        (CAS RN 1217890-37-3)","number_indents":3,"heading":{"goods_nomenclature_sid":38464,"goods_nomenclature_item_id":"3815000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Reaction
+        initiators, reaction accelerators and catalytic preparations, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"70737","_score":1.0,"_source":{"id":70737,"goods_nomenclature_item_id":"3815909081","producline_suffix":"80","validity_start_date":"1999-07-01T00:00:00+00:00","validity_end_date":null,"description":"Catalyst,
+        containing by weight 38% or more but not more than 48% of (2-hydroxy-1-methylethyl)trimethylammonium
+        2-ethylhexanoate","number_indents":3,"heading":{"goods_nomenclature_sid":38464,"goods_nomenclature_item_id":"3815000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Reaction
+        initiators, reaction accelerators and catalytic preparations, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"79285","_score":1.0,"_source":{"id":79285,"goods_nomenclature_item_id":"3815909086","producline_suffix":"80","validity_start_date":"2004-01-01T00:00:00+00:00","validity_end_date":null,"description":"Catalyst,
+        in the form of rodlets, consisting of an aluminosilicate (zeolite), containing
+        by weight 2% or more but not more than 3% of rare-earth metals oxides and
+        less than 1% of disodium oxide","number_indents":3,"heading":{"goods_nomenclature_sid":38464,"goods_nomenclature_item_id":"3815000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Reaction
+        initiators, reaction accelerators and catalytic preparations, not elsewhere
+        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"65263","_score":1.0,"_source":{"id":65263,"goods_nomenclature_item_id":"3824908500","producline_suffix":"80","validity_start_date":"1997-01-01T00:00:00+00:00","validity_end_date":null,"description":"3-(1-Ethyl-1-methylpropyl)isoxazol-5-ylamine,
+        in the form of a solution in toluene","number_indents":4,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
+        binders for foundry moulds or cores; chemical products and preparations of
+        the chemical or allied industries (including those consisting of mixtures
+        of natural products), not elsewhere specified or included; residual products
+        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91143","_score":1.0,"_source":{"id":91143,"goods_nomenclature_item_id":"3824909716","producline_suffix":"80","validity_start_date":"2009-07-01T00:00:00+00:00","validity_end_date":null,"description":"Mixture
+        of bis{4-(3-(3-phenoxycarbonylamino)tolyl)ureido}phenylsulphone, diphenyltoluene-2,4-dicarbamate
+        and 1-[4-(4-aminobenzenesulphonyl)-phenyl]-3-(3-phenoxycarbonylamino-tolyl)-urea","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
+        binders for foundry moulds or cores; chemical products and preparations of
+        the chemical or allied industries (including those consisting of mixtures
+        of natural products), not elsewhere specified or included; residual products
+        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97512","_score":1.0,"_source":{"id":97512,"goods_nomenclature_item_id":"3824909718","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"Poly(tetramethylene
+        glycol) bis[(9-oxo-9H-thioxanthen-1-yloxy)acetate]&nbsp;with an average polymer
+        chain length of less than 5&nbsp;monomer units (CAS RN 515136-48-8)","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
+        binders for foundry moulds or cores; chemical products and preparations of
+        the chemical or allied industries (including those consisting of mixtures
+        of natural products), not elsewhere specified or included; residual products
+        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92695","_score":1.0,"_source":{"id":92695,"goods_nomenclature_item_id":"3824909721","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"Mixture
+        of 2-propenoic acid, (1-methylethylidene)bis(4,1-phenyleneoxy-2,1-ethanediyloxy-2,1-ethanediyl)ester
+        with 2-propenoic acid, (2,4,6-trioxo-1,3,5-triazine-1,3,5(2H,4H,6H)-triyl)tri-2,1-ethanediyl
+        ester and 1-hydroxy-cyclohexyl-phenyl ketone in the solution of methyl ethyl
+        ketone and toluene","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
+        binders for foundry moulds or cores; chemical products and preparations of
+        the chemical or allied industries (including those consisting of mixtures
+        of natural products), not elsewhere specified or included; residual products
+        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96348","_score":1.0,"_source":{"id":96348,"goods_nomenclature_item_id":"3824909726","producline_suffix":"80","validity_start_date":"2012-07-01T00:00:00+00:00","validity_end_date":null,"description":"Aqueous
+        dispersion, containing&nbsp; by weight: <br/>\t\t\t\t\t\t<br/>-&nbsp;76%&nbsp;
+        (\u00b1&nbsp;0,5%)&nbsp;of silicon carbide (CAS RN&nbsp;409-21-2) <br/>\t\t\t\t\t\t<br/>-&nbsp;4,6%&nbsp;(\u00b1&nbsp;0,05%)
+        of aluminium oxide&nbsp;(CAS RN 1344-28-1)&nbsp;and <br/>\t\t\t\t\t\t<br/>-&nbsp;2,4%&nbsp;(\u00b1&nbsp;0,05%)&nbsp;of&nbsp;yttrium
+        oxide&nbsp;(CAS RN&nbsp;1314-36-9)","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
+        binders for foundry moulds or cores; chemical products and preparations of
+        the chemical or allied industries (including those consisting of mixtures
+        of natural products), not elsewhere specified or included; residual products
+        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96895","_score":1.0,"_source":{"id":96895,"goods_nomenclature_item_id":"3824909735","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"Mixture
+        of:<br/>-&nbsp;3,3-bis(2-methyl-1-octyl-1H-indol-3-yl)phthalide (CAS RN 50292-95-0)
+        and<br/>-&nbsp;ethyl-6''-(diethylamino)-3-oxo-spiro-[isobenzofuran-1(3H),9''-[9H]xanthene]-2''-carboxylate
+        (CAS RN 154306-60-2)","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
+        binders for foundry moulds or cores; chemical products and preparations of
+        the chemical or allied industries (including those consisting of mixtures
+        of natural products), not elsewhere specified or included; residual products
+        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97513","_score":1.0,"_source":{"id":97513,"goods_nomenclature_item_id":"3824909747","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"Platinum
+        oxide (CAS RN 12035-82-4) fixed on a porous support of aluminium oxide (CAS
+        RN 1344-28-1), containing by weight:<br/>-&nbsp;0,1% or more but not more
+        than 1% of platinum, and<br/>-&nbsp;0,5% or more but not more than 5% of ethylaluminium
+        dichloride (CAS RN 563-43-9)","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
+        binders for foundry moulds or cores; chemical products and preparations of
+        the chemical or allied industries (including those consisting of mixtures
+        of natural products), not elsewhere specified or included; residual products
+        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"89603","_score":1.0,"_source":{"id":89603,"goods_nomenclature_item_id":"3824909748","producline_suffix":"80","validity_start_date":"2008-01-01T00:00:00+00:00","validity_end_date":null,"description":"Rare-earth
+        concentrate containing by weight 60% or more but not more than 95% of rare-earth
         oxides and not more than 1% each of zirconium oxide, aluminium oxide or iron
-        oxide, and having a loss on ignition of 5% or more by weight","number_indents":2,"heading":{"goods_nomenclature_sid":36137,"goods_nomenclature_item_id":"2846000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Compounds,
-        inorganic or organic, of rare-earth metals, of yttrium or of scandium or of
-        mixtures of these metals","number_indents":0},"chapter":{"goods_nomenclature_sid":35719,"goods_nomenclature_item_id":"2800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Inorganic
-        chemicals; organic or inorganic compounds of precious metals, of rare-earth
-        metals, of radioactive elements or of isotopes"},"section":{"numeral":"VI","title":"Products
-        of the chemical or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97469","_score":1.0,"_source":{"id":97469,"goods_nomenclature_item_id":"2903399025","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"2,3,3,3-Tetrafluoroprop-1-ene
-        (CAS RN 754-12-1)","number_indents":4,"heading":{"goods_nomenclature_sid":36225,"goods_nomenclature_item_id":"2903000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Halogenated
-        derivatives of hydrocarbons","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"85177","_score":1.0,"_source":{"id":85177,"goods_nomenclature_item_id":"2903399050","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"1,1,1,3,3-Pentafluoropropane
-        (CAS RN 460-73-1)","number_indents":4,"heading":{"goods_nomenclature_sid":36225,"goods_nomenclature_item_id":"2903000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Halogenated
-        derivatives of hydrocarbons","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91124","_score":1.0,"_source":{"id":91124,"goods_nomenclature_item_id":"2903399075","producline_suffix":"80","validity_start_date":"2009-07-01T00:00:00+00:00","validity_end_date":null,"description":"Trans-1,3,3,3-tetrafluoroprop-1-ene
-        (CAS RN 1645-83-6)","number_indents":4,"heading":{"goods_nomenclature_sid":36225,"goods_nomenclature_item_id":"2903000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Halogenated
-        derivatives of hydrocarbons","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91426","_score":1.0,"_source":{"id":91426,"goods_nomenclature_item_id":"2923900045","producline_suffix":"80","validity_start_date":"2010-01-01T00:00:00+00:00","validity_end_date":null,"description":"Tetrabutylammonium
-        hydroxide in the form of an aqueous solution containing 55% (\u00b1&nbsp;
-        1%) by weight of tetrabutylammonium hydroxide (CAS RN 2052-49-5)","number_indents":2,"heading":{"goods_nomenclature_sid":36961,"goods_nomenclature_item_id":"2923000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Quaternary
-        ammonium salts and hydroxides; lecithins and other phosphoaminolipids","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93678","_score":1.0,"_source":{"id":93678,"goods_nomenclature_item_id":"2923900075","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"Tetraethylammonium
-        hydroxide, in the form of an aqueous solution containing: <br/>-&nbsp;35%
-        (\u00b1&nbsp;0,5%) by weight of tetraethylammonium hydroxide, <br/>-&nbsp;not
-        more than 1&nbsp;000&nbsp;mg/kg of chloride, <br/>-&nbsp;not more than 2&nbsp;mg/kg&nbsp;of
-        iron and <br/>-&nbsp;not more than 10&nbsp;mg/kg&nbsp;of potassium","number_indents":2,"heading":{"goods_nomenclature_sid":36961,"goods_nomenclature_item_id":"2923000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Quaternary
-        ammonium salts and hydroxides; lecithins and other phosphoaminolipids","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"81610","_score":1.0,"_source":{"id":81610,"goods_nomenclature_item_id":"2924190050","producline_suffix":"80","validity_start_date":"2005-07-01T00:00:00+00:00","validity_end_date":null,"description":"Acrylamide
-        (CAS RN 79-06-1)","number_indents":3,"heading":{"goods_nomenclature_sid":36969,"goods_nomenclature_item_id":"2924000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Carboxyamide-function
-        compounds; amide-function compounds of carbonic acid","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90470","_score":1.0,"_source":{"id":90470,"goods_nomenclature_item_id":"2924299815","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"Acetochlor
-        (ISO) (CAS RN 34256-82-1)","number_indents":4,"heading":{"goods_nomenclature_sid":36969,"goods_nomenclature_item_id":"2924000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Carboxyamide-function
-        compounds; amide-function compounds of carbonic acid","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93681","_score":1.0,"_source":{"id":93681,"goods_nomenclature_item_id":"2924299845","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"Propoxur
-        (ISO) (CAS RN 114-26-1)","number_indents":4,"heading":{"goods_nomenclature_sid":36969,"goods_nomenclature_item_id":"2924000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Carboxyamide-function
-        compounds; amide-function compounds of carbonic acid","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93684","_score":1.0,"_source":{"id":93684,"goods_nomenclature_item_id":"2924299860","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"N,N''-(2-Chloro-5-methyl-1,4-phenylene)bis[3-oxobutyramide]
-        (CAS RN 41131-65-1)","number_indents":4,"heading":{"goods_nomenclature_sid":36969,"goods_nomenclature_item_id":"2924000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Carboxyamide-function
-        compounds; amide-function compounds of carbonic acid","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"37014","_score":1.0,"_source":{"id":37014,"goods_nomenclature_item_id":"2926200000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"1-Cyanoguanidine
-        (dicyandiamide)","number_indents":1,"heading":{"goods_nomenclature_sid":37012,"goods_nomenclature_item_id":"2926000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Nitrile-function
-        compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"88354","_score":1.0,"_source":{"id":88354,"goods_nomenclature_item_id":"2926909561","producline_suffix":"80","validity_start_date":"2007-07-01T00:00:00+00:00","validity_end_date":null,"description":"m-(1-Cyanoethyl)benzoic
-        acid (CAS RN 5537-71-3)","number_indents":3,"heading":{"goods_nomenclature_sid":37012,"goods_nomenclature_item_id":"2926000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Nitrile-function
-        compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91427","_score":1.0,"_source":{"id":91427,"goods_nomenclature_item_id":"2926909563","producline_suffix":"80","validity_start_date":"2010-01-01T00:00:00+00:00","validity_end_date":null,"description":"1-(Cyanoacetyl)-3-ethylurea
-        (CAS RN 41078-06-2)","number_indents":3,"heading":{"goods_nomenclature_sid":37012,"goods_nomenclature_item_id":"2926000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Nitrile-function
-        compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"98089","_score":1.0,"_source":{"id":98089,"goods_nomenclature_item_id":"3105400010","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"Monoammonium
+        oxide, and having a loss on ignition of 5% or more by weight","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
+        binders for foundry moulds or cores; chemical products and preparations of
+        the chemical or allied industries (including those consisting of mixtures
+        of natural products), not elsewhere specified or included; residual products
+        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93717","_score":1.0,"_source":{"id":93717,"goods_nomenclature_item_id":"3824909758","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"N2-[1-(S)-Ethoxycarbonyl-3-phenylpropyl]-N6-trifluoroacetyl-L-lysyl-N2-carboxy
+        anhydride in a solution of dichloromethane at 37%","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
+        binders for foundry moulds or cores; chemical products and preparations of
+        the chemical or allied industries (including those consisting of mixtures
+        of natural products), not elsewhere specified or included; residual products
+        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93821","_score":1.0,"_source":{"id":93821,"goods_nomenclature_item_id":"3824909765","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"Preparation
+        containing by weight: <br/>-&nbsp;89% or more but not more than 98,9% of 1,2,3-trideoxy-4,6:5,7-bis-O-[(4-propylphenyl)methylene]-nonitol
+        <br/>-&nbsp;0,1% or more but not more than 1% of colorants <br/>-&nbsp;1%
+        or more but not more than 10% of fluoropolymers","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
+        binders for foundry moulds or cores; chemical products and preparations of
+        the chemical or allied industries (including those consisting of mixtures
+        of natural products), not elsewhere specified or included; residual products
+        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90749","_score":1.0,"_source":{"id":90749,"goods_nomenclature_item_id":"3824909779","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"Mixture
+        of 80% (\u00b1&nbsp;10%) of 1-[2-(2-aminobutoxy)ethoxy]but-2-ylamine and 20%(\u00b1&nbsp;10%)
+        of 1-({[2-(2-aminobutoxy)ethoxy]methyl} propoxy)but-2-ylamine","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
+        binders for foundry moulds or cores; chemical products and preparations of
+        the chemical or allied industries (including those consisting of mixtures
+        of natural products), not elsewhere specified or included; residual products
+        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"89640","_score":1.0,"_source":{"id":89640,"goods_nomenclature_item_id":"3824909784","producline_suffix":"80","validity_start_date":"2008-01-01T00:00:00+00:00","validity_end_date":null,"description":"Reaction
+        product, containing by weight:<br/>- 1% or more but not more than 40% of molybdenum
+        oxide,<br/>- 10% or more but not more than 50% of nickel oxide,<br/>- 30%
+        or more but not more than 70% of tungsten oxide","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
+        binders for foundry moulds or cores; chemical products and preparations of
+        the chemical or allied industries (including those consisting of mixtures
+        of natural products), not elsewhere specified or included; residual products
+        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"88928","_score":1.0,"_source":{"id":88928,"goods_nomenclature_item_id":"3824909798","producline_suffix":"80","validity_start_date":"2008-01-01T00:00:00+00:00","validity_end_date":null,"description":"Mixture
+        of tertiary amines containing by weight:<br/>- 2.0-4.0% of N,N-dimethyl-1-octanamine<br/>-
+        94% minimum of N,N-dimethyl-1-decanamine<br/>- 2% maximum of N,N-dimethyl-1-dodecanamine","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
+        binders for foundry moulds or cores; chemical products and preparations of
+        the chemical or allied industries (including those consisting of mixtures
+        of natural products), not elsewhere specified or included; residual products
+        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"98089","_score":1.0,"_source":{"id":98089,"goods_nomenclature_item_id":"3105400010","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"Monoammonium
         phosphate (CAS RN 7722-76-1)","number_indents":2,"heading":{"goods_nomenclature_sid":37820,"goods_nomenclature_item_id":"3105000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Mineral
         or chemical fertilisers containing two or three of the fertilising elements
         nitrogen, phosphorus and potassium; other fertilisers; goods of this chapter
@@ -1620,7 +1648,48 @@ http_interactions:
         for retail sale or as preparations or articles (for example, sulphur-treated
         bands, wicks and candles, and fly-papers)","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
         chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90777","_score":1.0,"_source":{"id":90777,"goods_nomenclature_item_id":"3923309010","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"Polyethylene
+        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"59804","_score":1.0,"_source":{"id":59804,"goods_nomenclature_item_id":"4408310000","producline_suffix":"10","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        tropical wood specified in subheading note&nbsp;1&nbsp;to this chapter","number_indents":1,"heading":{"goods_nomenclature_sid":40118,"goods_nomenclature_item_id":"4408000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Veneer
+        sheets and sheets for plywood (whether or not spliced) and other wood sawn
+        lengthwise, sliced or peeled, whether or not planed, sanded or finger-jointed,
+        of a thickness not exceeding&nbsp;6&nbsp;mm","number_indents":0},"chapter":{"goods_nomenclature_sid":39988,"goods_nomenclature_item_id":"4400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Wood
+        and articles of wood; wood charcoal"},"section":{"numeral":"IX","title":"Wood
+        and articles of wood; wood charcoal; cork and articles of cork; manufactures
+        of straw, of esparto or of other plaiting materials; basket-ware and wickerwork","position":9}}},{"_index":"tariff-commodities","_type":"commodity","_id":"73697","_score":1.0,"_source":{"id":73697,"goods_nomenclature_item_id":"4408398500","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a thickness not exceeding 1&nbsp;mm","number_indents":6,"heading":{"goods_nomenclature_sid":40118,"goods_nomenclature_item_id":"4408000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Veneer
+        sheets and sheets for plywood (whether or not spliced) and other wood sawn
+        lengthwise, sliced or peeled, whether or not planed, sanded or finger-jointed,
+        of a thickness not exceeding&nbsp;6&nbsp;mm","number_indents":0},"chapter":{"goods_nomenclature_sid":39988,"goods_nomenclature_item_id":"4400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Wood
+        and articles of wood; wood charcoal"},"section":{"numeral":"IX","title":"Wood
+        and articles of wood; wood charcoal; cork and articles of cork; manufactures
+        of straw, of esparto or of other plaiting materials; basket-ware and wickerwork","position":9}}},{"_index":"tariff-commodities","_type":"commodity","_id":"73698","_score":1.0,"_source":{"id":73698,"goods_nomenclature_item_id":"4408399500","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a thickness exceeding 1&nbsp;mm","number_indents":6,"heading":{"goods_nomenclature_sid":40118,"goods_nomenclature_item_id":"4408000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Veneer
+        sheets and sheets for plywood (whether or not spliced) and other wood sawn
+        lengthwise, sliced or peeled, whether or not planed, sanded or finger-jointed,
+        of a thickness not exceeding&nbsp;6&nbsp;mm","number_indents":0},"chapter":{"goods_nomenclature_sid":39988,"goods_nomenclature_item_id":"4400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Wood
+        and articles of wood; wood charcoal"},"section":{"numeral":"IX","title":"Wood
+        and articles of wood; wood charcoal; cork and articles of cork; manufactures
+        of straw, of esparto or of other plaiting materials; basket-ware and wickerwork","position":9}}},{"_index":"tariff-commodities","_type":"commodity","_id":"73700","_score":1.0,"_source":{"id":73700,"goods_nomenclature_item_id":"4408908500","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a thickness not exceeding 1&nbsp;mm","number_indents":4,"heading":{"goods_nomenclature_sid":40118,"goods_nomenclature_item_id":"4408000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Veneer
+        sheets and sheets for plywood (whether or not spliced) and other wood sawn
+        lengthwise, sliced or peeled, whether or not planed, sanded or finger-jointed,
+        of a thickness not exceeding&nbsp;6&nbsp;mm","number_indents":0},"chapter":{"goods_nomenclature_sid":39988,"goods_nomenclature_item_id":"4400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Wood
+        and articles of wood; wood charcoal"},"section":{"numeral":"IX","title":"Wood
+        and articles of wood; wood charcoal; cork and articles of cork; manufactures
+        of straw, of esparto or of other plaiting materials; basket-ware and wickerwork","position":9}}},{"_index":"tariff-commodities","_type":"commodity","_id":"73701","_score":1.0,"_source":{"id":73701,"goods_nomenclature_item_id":"4408909500","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a thickness exceeding 1&nbsp;mm","number_indents":4,"heading":{"goods_nomenclature_sid":40118,"goods_nomenclature_item_id":"4408000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Veneer
+        sheets and sheets for plywood (whether or not spliced) and other wood sawn
+        lengthwise, sliced or peeled, whether or not planed, sanded or finger-jointed,
+        of a thickness not exceeding&nbsp;6&nbsp;mm","number_indents":0},"chapter":{"goods_nomenclature_sid":39988,"goods_nomenclature_item_id":"4400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Wood
+        and articles of wood; wood charcoal"},"section":{"numeral":"IX","title":"Wood
+        and articles of wood; wood charcoal; cork and articles of cork; manufactures
+        of straw, of esparto or of other plaiting materials; basket-ware and wickerwork","position":9}}},{"_index":"tariff-commodities","_type":"commodity","_id":"86206","_score":1.0,"_source":{"id":86206,"goods_nomenclature_item_id":"4412310000","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
+        at least one outer ply of tropical wood specified in subheading note 1&nbsp;to
+        this chapter","number_indents":2,"heading":{"goods_nomenclature_sid":40191,"goods_nomenclature_item_id":"4412000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Plywood,
+        veneered panels and similar laminated wood","number_indents":0},"chapter":{"goods_nomenclature_sid":39988,"goods_nomenclature_item_id":"4400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Wood
+        and articles of wood; wood charcoal"},"section":{"numeral":"IX","title":"Wood
+        and articles of wood; wood charcoal; cork and articles of cork; manufactures
+        of straw, of esparto or of other plaiting materials; basket-ware and wickerwork","position":9}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90777","_score":1.0,"_source":{"id":90777,"goods_nomenclature_item_id":"3923309010","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"Polyethylene
         container, for compressed hydrogen:<br/>-&nbsp;with aluminium bosses at both
         ends,<br/>-&nbsp;wholly embedded in an overwrap of carbon fibres impregnated
         with epoxide resin,<br/>-&nbsp;of a diameter of 213&nbsp;mm or more, but not
@@ -1856,128 +1925,191 @@ http_interactions:
         plates, sheets, film, foil and strip, of plastics, non-cellular and not reinforced,
         laminated, supported or similarly combined with other materials","number_indents":0},"chapter":{"goods_nomenclature_sid":38659,"goods_nomenclature_item_id":"3900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Plastics
         and articles thereof"},"section":{"numeral":"VII","title":"Plastics and articles
-        thereof; rubber and articles thereof","position":7}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95638","_score":1.0,"_source":{"id":95638,"goods_nomenclature_item_id":"4810130020","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
-        a weight of 70&nbsp;g/m2 or more but not more than 400&nbsp;g/m2 and brightness
-        of more than 84 (measured according to ISO 2470-1), excluding multi-ply paper
-        and multi-ply paperboard and excluding rolls suitable for use in web-fed presses","number_indents":3,"heading":{"goods_nomenclature_sid":40591,"goods_nomenclature_item_id":"4810000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Paper
-        and paperboard, coated on one or both sides with kaolin (China clay) or other
-        inorganic substances, with or without a binder, and with no other coating,
-        whether or not surface-coloured, surface-decorated or printed, in rolls or
-        sheets","number_indents":0},"chapter":{"goods_nomenclature_sid":40400,"goods_nomenclature_item_id":"4800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Paper
-        and paperboard; articles of paper pulp, of paper or of paperboard"},"section":{"numeral":"X","title":"Pulp
-        of wood or of other fibrous cellulosic material; recovered (waste and scrap)
-        paper or paperboard; paper and paperboard and articles thereof","position":10}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95667","_score":1.0,"_source":{"id":95667,"goods_nomenclature_item_id":"4810140020","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
-        a weight of 70&nbsp;g/m2 or more but not more than 400&nbsp;g/m2 and brightness
-        of more than 84 (measured according to ISO 2470-1), excluding multi-ply paper
-        and multi-ply paperboard","number_indents":3,"heading":{"goods_nomenclature_sid":40591,"goods_nomenclature_item_id":"4810000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Paper
-        and paperboard, coated on one or both sides with kaolin (China clay) or other
-        inorganic substances, with or without a binder, and with no other coating,
-        whether or not surface-coloured, surface-decorated or printed, in rolls or
-        sheets","number_indents":0},"chapter":{"goods_nomenclature_sid":40400,"goods_nomenclature_item_id":"4800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Paper
-        and paperboard; articles of paper pulp, of paper or of paperboard"},"section":{"numeral":"X","title":"Pulp
-        of wood or of other fibrous cellulosic material; recovered (waste and scrap)
-        paper or paperboard; paper and paperboard and articles thereof","position":10}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95670","_score":1.0,"_source":{"id":95670,"goods_nomenclature_item_id":"4810190020","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
-        a weight of 70&nbsp;g/m2 or more but not more than 400&nbsp;g/m2 and brightness
-        of more than 84 (measured according to ISO 2470-1), excluding multi-ply paper
-        and multi-ply paperboard","number_indents":3,"heading":{"goods_nomenclature_sid":40591,"goods_nomenclature_item_id":"4810000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Paper
-        and paperboard, coated on one or both sides with kaolin (China clay) or other
-        inorganic substances, with or without a binder, and with no other coating,
-        whether or not surface-coloured, surface-decorated or printed, in rolls or
-        sheets","number_indents":0},"chapter":{"goods_nomenclature_sid":40400,"goods_nomenclature_item_id":"4800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Paper
-        and paperboard; articles of paper pulp, of paper or of paperboard"},"section":{"numeral":"X","title":"Pulp
-        of wood or of other fibrous cellulosic material; recovered (waste and scrap)
-        paper or paperboard; paper and paperboard and articles thereof","position":10}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95672","_score":1.0,"_source":{"id":95672,"goods_nomenclature_item_id":"4810220020","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
-        a weight of 70&nbsp;g/m2 or more but not more than 400&nbsp;g/m2 and brightness
-        of more than 84 (measured according to ISO 2470-1), excluding multi-ply paper
-        and multi-ply paperboard and excluding rolls suitable for use in web-fed presses","number_indents":3,"heading":{"goods_nomenclature_sid":40591,"goods_nomenclature_item_id":"4810000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Paper
-        and paperboard, coated on one or both sides with kaolin (China clay) or other
-        inorganic substances, with or without a binder, and with no other coating,
-        whether or not surface-coloured, surface-decorated or printed, in rolls or
-        sheets","number_indents":0},"chapter":{"goods_nomenclature_sid":40400,"goods_nomenclature_item_id":"4800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Paper
-        and paperboard; articles of paper pulp, of paper or of paperboard"},"section":{"numeral":"X","title":"Pulp
-        of wood or of other fibrous cellulosic material; recovered (waste and scrap)
-        paper or paperboard; paper and paperboard and articles thereof","position":10}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93463","_score":1.0,"_source":{"id":93463,"goods_nomenclature_item_id":"4810293020","producline_suffix":"80","validity_start_date":"2010-11-18T00:00:00+00:00","validity_end_date":null,"description":"With
-        a weight of 70&nbsp;g/m2 or more but not more than 400&nbsp;g/m2 and brightness
-        of more than 84 (measured according to ISO 2470-1), excluding multi-ply paper
-        and multi-ply paperboard and excluding rolls suitable for use in web-fed presses","number_indents":4,"heading":{"goods_nomenclature_sid":40591,"goods_nomenclature_item_id":"4810000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Paper
-        and paperboard, coated on one or both sides with kaolin (China clay) or other
-        inorganic substances, with or without a binder, and with no other coating,
-        whether or not surface-coloured, surface-decorated or printed, in rolls or
-        sheets","number_indents":0},"chapter":{"goods_nomenclature_sid":40400,"goods_nomenclature_item_id":"4800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Paper
-        and paperboard; articles of paper pulp, of paper or of paperboard"},"section":{"numeral":"X","title":"Pulp
-        of wood or of other fibrous cellulosic material; recovered (waste and scrap)
-        paper or paperboard; paper and paperboard and articles thereof","position":10}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93464","_score":1.0,"_source":{"id":93464,"goods_nomenclature_item_id":"4810298020","producline_suffix":"80","validity_start_date":"2010-11-18T00:00:00+00:00","validity_end_date":null,"description":"With
-        a weight of 70&nbsp;g/m2 or more but not more than 400&nbsp;g/m2 and brightness
-        of more than 84 (measured according to ISO 2470-1), excluding multi-ply paper
-        and multi-ply paperboard","number_indents":4,"heading":{"goods_nomenclature_sid":40591,"goods_nomenclature_item_id":"4810000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Paper
-        and paperboard, coated on one or both sides with kaolin (China clay) or other
-        inorganic substances, with or without a binder, and with no other coating,
-        whether or not surface-coloured, surface-decorated or printed, in rolls or
-        sheets","number_indents":0},"chapter":{"goods_nomenclature_sid":40400,"goods_nomenclature_item_id":"4800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Paper
-        and paperboard; articles of paper pulp, of paper or of paperboard"},"section":{"numeral":"X","title":"Pulp
-        of wood or of other fibrous cellulosic material; recovered (waste and scrap)
-        paper or paperboard; paper and paperboard and articles thereof","position":10}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93465","_score":1.0,"_source":{"id":93465,"goods_nomenclature_item_id":"4810991020","producline_suffix":"80","validity_start_date":"2010-11-18T00:00:00+00:00","validity_end_date":null,"description":"With
-        a weight of 70&nbsp;g/m2 or more but not more than 400&nbsp;g/m2 and brightness
-        of more than 84 (measured according to ISO 2470-1), excluding rolls suitable
-        for use in web-fed presses","number_indents":4,"heading":{"goods_nomenclature_sid":40591,"goods_nomenclature_item_id":"4810000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Paper
-        and paperboard, coated on one or both sides with kaolin (China clay) or other
-        inorganic substances, with or without a binder, and with no other coating,
-        whether or not surface-coloured, surface-decorated or printed, in rolls or
-        sheets","number_indents":0},"chapter":{"goods_nomenclature_sid":40400,"goods_nomenclature_item_id":"4800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Paper
-        and paperboard; articles of paper pulp, of paper or of paperboard"},"section":{"numeral":"X","title":"Pulp
-        of wood or of other fibrous cellulosic material; recovered (waste and scrap)
-        paper or paperboard; paper and paperboard and articles thereof","position":10}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95676","_score":1.0,"_source":{"id":95676,"goods_nomenclature_item_id":"4810998020","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
-        a weight of 70&nbsp;g/m2 or more but not more than 400&nbsp;g/m2 and brightness
-        of more than 84 (measured according to ISO 2470-1), excluding rolls suitable
-        for use in web-fed presses","number_indents":4,"heading":{"goods_nomenclature_sid":40591,"goods_nomenclature_item_id":"4810000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Paper
-        and paperboard, coated on one or both sides with kaolin (China clay) or other
-        inorganic substances, with or without a binder, and with no other coating,
-        whether or not surface-coloured, surface-decorated or printed, in rolls or
-        sheets","number_indents":0},"chapter":{"goods_nomenclature_sid":40400,"goods_nomenclature_item_id":"4800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Paper
-        and paperboard; articles of paper pulp, of paper or of paperboard"},"section":{"numeral":"X","title":"Pulp
-        of wood or of other fibrous cellulosic material; recovered (waste and scrap)
-        paper or paperboard; paper and paperboard and articles thereof","position":10}}},{"_index":"tariff-commodities","_type":"commodity","_id":"59804","_score":1.0,"_source":{"id":59804,"goods_nomenclature_item_id":"4408310000","producline_suffix":"10","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        tropical wood specified in subheading note&nbsp;1&nbsp;to this chapter","number_indents":1,"heading":{"goods_nomenclature_sid":40118,"goods_nomenclature_item_id":"4408000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Veneer
-        sheets and sheets for plywood (whether or not spliced) and other wood sawn
-        lengthwise, sliced or peeled, whether or not planed, sanded or finger-jointed,
-        of a thickness not exceeding&nbsp;6&nbsp;mm","number_indents":0},"chapter":{"goods_nomenclature_sid":39988,"goods_nomenclature_item_id":"4400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Wood
-        and articles of wood; wood charcoal"},"section":{"numeral":"IX","title":"Wood
-        and articles of wood; wood charcoal; cork and articles of cork; manufactures
-        of straw, of esparto or of other plaiting materials; basket-ware and wickerwork","position":9}}},{"_index":"tariff-commodities","_type":"commodity","_id":"73697","_score":1.0,"_source":{"id":73697,"goods_nomenclature_item_id":"4408398500","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a thickness not exceeding 1&nbsp;mm","number_indents":6,"heading":{"goods_nomenclature_sid":40118,"goods_nomenclature_item_id":"4408000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Veneer
-        sheets and sheets for plywood (whether or not spliced) and other wood sawn
-        lengthwise, sliced or peeled, whether or not planed, sanded or finger-jointed,
-        of a thickness not exceeding&nbsp;6&nbsp;mm","number_indents":0},"chapter":{"goods_nomenclature_sid":39988,"goods_nomenclature_item_id":"4400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Wood
-        and articles of wood; wood charcoal"},"section":{"numeral":"IX","title":"Wood
-        and articles of wood; wood charcoal; cork and articles of cork; manufactures
-        of straw, of esparto or of other plaiting materials; basket-ware and wickerwork","position":9}}},{"_index":"tariff-commodities","_type":"commodity","_id":"73698","_score":1.0,"_source":{"id":73698,"goods_nomenclature_item_id":"4408399500","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a thickness exceeding 1&nbsp;mm","number_indents":6,"heading":{"goods_nomenclature_sid":40118,"goods_nomenclature_item_id":"4408000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Veneer
-        sheets and sheets for plywood (whether or not spliced) and other wood sawn
-        lengthwise, sliced or peeled, whether or not planed, sanded or finger-jointed,
-        of a thickness not exceeding&nbsp;6&nbsp;mm","number_indents":0},"chapter":{"goods_nomenclature_sid":39988,"goods_nomenclature_item_id":"4400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Wood
-        and articles of wood; wood charcoal"},"section":{"numeral":"IX","title":"Wood
-        and articles of wood; wood charcoal; cork and articles of cork; manufactures
-        of straw, of esparto or of other plaiting materials; basket-ware and wickerwork","position":9}}},{"_index":"tariff-commodities","_type":"commodity","_id":"73700","_score":1.0,"_source":{"id":73700,"goods_nomenclature_item_id":"4408908500","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a thickness not exceeding 1&nbsp;mm","number_indents":4,"heading":{"goods_nomenclature_sid":40118,"goods_nomenclature_item_id":"4408000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Veneer
-        sheets and sheets for plywood (whether or not spliced) and other wood sawn
-        lengthwise, sliced or peeled, whether or not planed, sanded or finger-jointed,
-        of a thickness not exceeding&nbsp;6&nbsp;mm","number_indents":0},"chapter":{"goods_nomenclature_sid":39988,"goods_nomenclature_item_id":"4400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Wood
-        and articles of wood; wood charcoal"},"section":{"numeral":"IX","title":"Wood
-        and articles of wood; wood charcoal; cork and articles of cork; manufactures
-        of straw, of esparto or of other plaiting materials; basket-ware and wickerwork","position":9}}},{"_index":"tariff-commodities","_type":"commodity","_id":"73701","_score":1.0,"_source":{"id":73701,"goods_nomenclature_item_id":"4408909500","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a thickness exceeding 1&nbsp;mm","number_indents":4,"heading":{"goods_nomenclature_sid":40118,"goods_nomenclature_item_id":"4408000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Veneer
-        sheets and sheets for plywood (whether or not spliced) and other wood sawn
-        lengthwise, sliced or peeled, whether or not planed, sanded or finger-jointed,
-        of a thickness not exceeding&nbsp;6&nbsp;mm","number_indents":0},"chapter":{"goods_nomenclature_sid":39988,"goods_nomenclature_item_id":"4400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Wood
-        and articles of wood; wood charcoal"},"section":{"numeral":"IX","title":"Wood
-        and articles of wood; wood charcoal; cork and articles of cork; manufactures
-        of straw, of esparto or of other plaiting materials; basket-ware and wickerwork","position":9}}},{"_index":"tariff-commodities","_type":"commodity","_id":"86206","_score":1.0,"_source":{"id":86206,"goods_nomenclature_item_id":"4412310000","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
-        at least one outer ply of tropical wood specified in subheading note 1&nbsp;to
-        this chapter","number_indents":2,"heading":{"goods_nomenclature_sid":40191,"goods_nomenclature_item_id":"4412000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Plywood,
-        veneered panels and similar laminated wood","number_indents":0},"chapter":{"goods_nomenclature_sid":39988,"goods_nomenclature_item_id":"4400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Wood
-        and articles of wood; wood charcoal"},"section":{"numeral":"IX","title":"Wood
-        and articles of wood; wood charcoal; cork and articles of cork; manufactures
-        of straw, of esparto or of other plaiting materials; basket-ware and wickerwork","position":9}}},{"_index":"tariff-commodities","_type":"commodity","_id":"69357","_score":1.0,"_source":{"id":69357,"goods_nomenclature_item_id":"3902100010","producline_suffix":"80","validity_start_date":"1998-01-01T00:00:00+00:00","validity_end_date":null,"description":"Polypropylene
+        thereof; rubber and articles thereof","position":7}}},{"_index":"tariff-commodities","_type":"commodity","_id":"81280","_score":1.0,"_source":{"id":81280,"goods_nomenclature_item_id":"2933599515","producline_suffix":"80","validity_start_date":"2005-01-01T00:00:00+00:00","validity_end_date":null,"description":"(2_R_)-4-Oxo-4-[3-(trifluoromethyl)-5,6-dihydro[1,2,4]triazolo[4,3-_a_]
+        pyrazin-7(8_H_)-yl]-1-(2,4,5-trifluorophenyl)butyl-2-ammonium phosphate monohydrate","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92669","_score":1.0,"_source":{"id":92669,"goods_nomenclature_item_id":"2933599545","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"1-[3-(Hydroxymethyl)pyridin-2-yl]-4-methyl-2-phenylpiperazine
+        (CAS RN 61337-89-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92670","_score":1.0,"_source":{"id":92670,"goods_nomenclature_item_id":"2933599550","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"2-(2-Piperazin-1-ylethoxy)ethanol
+        (CAS RN 13349-82-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92672","_score":1.0,"_source":{"id":92672,"goods_nomenclature_item_id":"2933599565","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"1-Chloromethyl-4-fluoro-1,4-diazoniabicyclo[2.2.2]octane
+        bis(tetrafluoroborate) (CAS RN 140681-55-6)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"75256","_score":1.0,"_source":{"id":75256,"goods_nomenclature_item_id":"2933599570","producline_suffix":"80","validity_start_date":"2002-07-01T00:00:00+00:00","validity_end_date":null,"description":"_N_-(4-Ethyl-2,3-dioxopiperazin-1-ylcarbonyl)-D-2-phenylglycine
+        (CAS RN 63422-71-9)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92673","_score":1.0,"_source":{"id":92673,"goods_nomenclature_item_id":"2933599575","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"(2R,3S/2S,3R)-3-(6-Chloro-5-fluoro
+        pyrimidin-4-yl)-2-(2,4-difluorophenyl)-1-(1H-1,2,4-triazol-1-yl)butan-2-ol
+        hydrochloride (CAS RN 188416-20-8)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96844","_score":1.0,"_source":{"id":96844,"goods_nomenclature_item_id":"2933599577","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"3-(Trifluoromethyl)-5,6,7,8-tetrahydro[1,2,4]triazolo[4,3-a]pyrazine
+        hydrochloride (1:1) (CAS RN 762240-92-6)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"94001","_score":1.0,"_source":{"id":94001,"goods_nomenclature_item_id":"2933698025","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"1,3,5-Triazine-2,4,6-triamine
+        monophosphate&nbsp;(CAS RN 20208-95-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93186","_score":1.0,"_source":{"id":93186,"goods_nomenclature_item_id":"2933790070","producline_suffix":"80","validity_start_date":"2011-01-01T00:00:00+00:00","validity_end_date":null,"description":"(S)-N-[(Diethylamino)methyl]-alpha-ethyl-2-oxo-1-pyrrolidineacetamide
+        L-(+)-tartrate (CAS RN 754186-36-2)","number_indents":3,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"94005","_score":1.0,"_source":{"id":94005,"goods_nomenclature_item_id":"2933998013","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"5-Difluormethoxy-2-mercapto-1-H-benzimidazole&nbsp;(CAS
+        RN 97963-62-7)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90498","_score":1.0,"_source":{"id":90498,"goods_nomenclature_item_id":"2933998015","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"2-(2_H_-Benzotriazol-2-yl)-4,6-di-_tert_-pentylphenol
+        (CAS RN 25973-55-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90499","_score":1.0,"_source":{"id":90499,"goods_nomenclature_item_id":"2933998020","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"2-(2_H_-Benzotriazol-2-yl)-4,6-bis(1-methyl-1-phenylethyl)phenol","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96846","_score":1.0,"_source":{"id":96846,"goods_nomenclature_item_id":"2933998022","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"(2S)-2-Benzyl-N,N-dimethylaziridine-1-sulfonamide
+        (CAS RN 902146-43-4)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92676","_score":1.0,"_source":{"id":92676,"goods_nomenclature_item_id":"2933998037","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"8-Chloro-5,10-dihydro-11H-dibenzo
+        [b,e] [1,4]diazepin-11-one (CAS RN 50892-62-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97874","_score":1.0,"_source":{"id":97874,"goods_nomenclature_item_id":"2933998053","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"Potassium
+        (S)-5-(tert-butoxycarbonyl)-5-azaspiro[2.4]heptane-6-carboxylate (CUS&nbsp;0133723-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97875","_score":1.0,"_source":{"id":97875,"goods_nomenclature_item_id":"2933998057","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"2-(5-Methoxyindol-3-yl)ethylamine
+        (CAS RN 608-07-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93695","_score":1.0,"_source":{"id":93695,"goods_nomenclature_item_id":"2933998064","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"((3R)-1-{(1R,2R)-2-[2-(3,4-Dimethoxyphenyl)
+        ethoxy]cyclohexyl}pyrrolidin-3-ol.hydrochloride (CAS RN 748810-28-8)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90730","_score":1.0,"_source":{"id":90730,"goods_nomenclature_item_id":"2933998076","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"Manganese(2+),
+        bis(octahydro-1,4,7-trimethyl-1H-1,4,7-triazonine-N1,N4,N7)tri-\u03bc-oxodi-,
+        acetate (1:2)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90514","_score":1.0,"_source":{"id":90514,"goods_nomenclature_item_id":"2933998082","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"Tolyltriazole
+        (CAS RN 29385-43-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90517","_score":1.0,"_source":{"id":90517,"goods_nomenclature_item_id":"2933998088","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"2,6-dichloroquinoxaline
+        (CAS RN 18671-97-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"94008","_score":1.0,"_source":{"id":94008,"goods_nomenclature_item_id":"2934208020","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"S-1,3-Benzothiazol-2-yl
+        (2Z)-(5-amino-1,2,4-thiadiazol-3-yl)(methoxyimino)ethanethioate (CAS RN 89604-91-1)","number_indents":3,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"94009","_score":1.0,"_source":{"id":94009,"goods_nomenclature_item_id":"2934208030","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"2-[[(Z)-[1-(2-Amino-4-thiazolyl)-2-(2-benzothiazolylthio)-2-oxoethylidene]amino]oxy]-acetic
+        acid, methyl ester&nbsp;(CAS RN 246035-38-1)","number_indents":3,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90520","_score":1.0,"_source":{"id":90520,"goods_nomenclature_item_id":"2934996000","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"Chlorprothixene
+        (INN); thenalidine (INN) and its tartrates and maleates; furazolidone (INN);
+        7-aminocephalosporanic acid; salts and esters of (6R,7R)-3-acetoxymethyl-7-[(R)-2-formyloxy-2-phenylacetamido]-8-oxo-5-thia-1-azabicyclo[4.2.0]oct-2-ene-2-carboxylic
+        acid; 1-[2-(1,3-dioxan-2-yl)ethyl]-2-methylpyridinium bromide","number_indents":3,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96855","_score":1.0,"_source":{"id":96855,"goods_nomenclature_item_id":"2934999014","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"Ethyl
+        N-{[1-methyl-2-({[4-(5-oxo-4,5-dihydro-1,2,4-oxadiazol-3-yl)phenyl]amino}methyl)-1H-benzimidazol-5-yl]carbonyl}-N-pyridin-2-yl-b-alaninate
+        (CAS RN 872728-84-2)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"94010","_score":1.0,"_source":{"id":94010,"goods_nomenclature_item_id":"2934999017","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"Methyl(1,8-diethyl-1,3,4,9-tetrahydropyrano[3,4-b]indol-1-yl)acetate
+        (CAS RN 122188-02-7)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96856","_score":1.0,"_source":{"id":96856,"goods_nomenclature_item_id":"2934999018","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"3,3-bis(2-Methyl-1-octyl-1H-indol-3-yl)phthalide
+        (CAS RN 50292-95-0)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92679","_score":1.0,"_source":{"id":92679,"goods_nomenclature_item_id":"2934999020","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"Thiophene
+        (CAS RN 110-02-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96857","_score":1.0,"_source":{"id":96857,"goods_nomenclature_item_id":"2934999022","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"7-[4-(Diethylamino)-2-ethoxyphenyl]-7-(2-methyl-1-octyl-1H-indol-3-yl)
+        furo[3,4-b]pyridin-5(7H)-one (CAS RN 87563-89-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"94012","_score":1.0,"_source":{"id":94012,"goods_nomenclature_item_id":"2934999028","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"11-(Piperazin-1-yl)dibenzo[b,f][1,4]thiazepine
+        dihydrochloride&nbsp;(CAS RN 111974-74-4)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93148","_score":1.0,"_source":{"id":93148,"goods_nomenclature_item_id":"2934999040","producline_suffix":"80","validity_start_date":"2011-01-01T00:00:00+00:00","validity_end_date":null,"description":"2-Thiophene
+        ethylamine (CAS RN 30433-91-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96346","_score":1.0,"_source":{"id":96346,"goods_nomenclature_item_id":"2934999048","producline_suffix":"80","validity_start_date":"2012-07-01T00:00:00+00:00","validity_end_date":null,"description":"Propan-2-ol&nbsp;--&nbsp;2-methyl-4-(4-methylpiperazin-1-yl)-10H-thieno[2,3-b][1,5]benzodiazepine
+        (1:2) dihydrate, (CAS RN 864743-41-9)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93149","_score":1.0,"_source":{"id":93149,"goods_nomenclature_item_id":"2934999050","producline_suffix":"80","validity_start_date":"2011-01-01T00:00:00+00:00","validity_end_date":null,"description":"10-[1,1''-Biphenyl]-4-yl-2-(1-methylethyl)-9-oxo-9H-thioxanthenium
+        hexafluorophosphate (CAS RN 591773-92-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"80562","_score":1.0,"_source":{"id":80562,"goods_nomenclature_item_id":"2934999072","producline_suffix":"80","validity_start_date":"2004-07-01T00:00:00+00:00","validity_end_date":null,"description":"1-[3-(5-Nitro-2-furyl)allylideneamino]imidazolidine-2,4-dione
+        (CAS RN 1672-88-4)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"88776","_score":1.0,"_source":{"id":88776,"goods_nomenclature_item_id":"2934999074","producline_suffix":"80","validity_start_date":"2008-01-01T00:00:00+00:00","validity_end_date":null,"description":"2-Isopropylthioxanthone
+        (CAS RN 5495-84-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"86734","_score":1.0,"_source":{"id":86734,"goods_nomenclature_item_id":"2934999075","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"(4R-cis)-1,1-Dimethylethyl-6-[2[2-(4-fluorophenyl)-5-(1-isopropyl)-3-phenyl-4-[(phenylamino)carbonyl]-1H-pyrrol-1-yl]ethyl]-2,2-dimethyl-1,3-dioxane-4-acetate
+        (CAS RN 125971-95-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90736","_score":1.0,"_source":{"id":90736,"goods_nomenclature_item_id":"2934999079","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"Thiophen-2-ethanol
+        (CAS RN 5402-55-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91440","_score":1.0,"_source":{"id":91440,"goods_nomenclature_item_id":"2934999084","producline_suffix":"80","validity_start_date":"2010-01-01T00:00:00+00:00","validity_end_date":null,"description":"Etoxazole
+        (ISO) of a purity by weight of 94,8% or more (CAS RN 153233-91-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93696","_score":1.0,"_source":{"id":93696,"goods_nomenclature_item_id":"2934999085","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"N2-[1-(S)-Ethoxycarbonyl-3-phenylpropyl]-N6-trifluoroacetyl-L-lysyl-N2-carboxy
+        anhydride (CAS RN 126586-91-2)","number_indents":4,"heading":{"goods_nomenclature_sid":37349,"goods_nomenclature_item_id":"2934000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        heterocyclic compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90521","_score":1.0,"_source":{"id":90521,"goods_nomenclature_item_id":"2935003000","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"3-{1-[7-(Hexadecylsulphonylamino)-1H-indole-3-yl]-3-oxo-1H,3H-naphtho[1,8-cd]pyran-1-yl}-N,N-dimethyl-1H-indole-7-sulphonamide;
+        metosulam (ISO)","number_indents":1,"heading":{"goods_nomenclature_sid":37418,"goods_nomenclature_item_id":"2935000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Sulphonamides","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97881","_score":1.0,"_source":{"id":97881,"goods_nomenclature_item_id":"2935009017","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"6-Methyl-4-oxo-5,6-dihydro-4H-thieno[2,3-b]thiopyran-2-sulfonamide
+        (CAS RN 120279-88-1)","number_indents":2,"heading":{"goods_nomenclature_sid":37418,"goods_nomenclature_item_id":"2935000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Sulphonamides","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96347","_score":1.0,"_source":{"id":96347,"goods_nomenclature_item_id":"2935009048","producline_suffix":"80","validity_start_date":"2012-07-01T00:00:00+00:00","validity_end_date":null,"description":"(3R,5S,6E)-7-[4-(4-Fluorophenyl)-2-[methyl(methylsulfonyl)amino]-6-(propan-2-yl)pyrimidin-5-yl]-3,5-dihydroxyhept-6-enoic
+        acid&nbsp;--&nbsp;1-[(R)-(4-chlorophenyl)(phenyl)methyl]piperazine (1:1),
+        (CAS RN 1235588-99-4)","number_indents":2,"heading":{"goods_nomenclature_sid":37418,"goods_nomenclature_item_id":"2935000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Sulphonamides","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92681","_score":1.0,"_source":{"id":92681,"goods_nomenclature_item_id":"2935009077","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"[[4-[2-[[(3-Ethyl-2,5-dihydro-4-methyl-2-oxo-1H-pyrrol-1-yl)carbonyl]amino]
+        ethyl]phenyl]sulfonyl]-carbamic acid ethyl ester (CAS RN 318515-70-7)","number_indents":2,"heading":{"goods_nomenclature_sid":37418,"goods_nomenclature_item_id":"2935000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Sulphonamides","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"86740","_score":1.0,"_source":{"id":86740,"goods_nomenclature_item_id":"2935009089","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"3-(3-Bromo-6-fluoro-2-methylindol-1-ylsulphonyl)-N,N-dimethyl-1,2,4-triazol-1-sulphonamide
+        (CAS RN 348635-87-0)","number_indents":2,"heading":{"goods_nomenclature_sid":37418,"goods_nomenclature_item_id":"2935000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Sulphonamides","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"37437","_score":1.0,"_source":{"id":37437,"goods_nomenclature_item_id":"2936220000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Vitamin&nbsp;B<sub>1</sub>&nbsp;and
+        its derivatives","number_indents":2,"heading":{"goods_nomenclature_sid":37433,"goods_nomenclature_item_id":"2936000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Provitamins
+        and vitamins, natural or reproduced by synthesis (including natural concentrates),
+        derivatives thereof used primarily as vitamins, and intermixtures of the foregoing,
+        whether or not in any solvent","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"37444","_score":1.0,"_source":{"id":37444,"goods_nomenclature_item_id":"2936260000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Vitamin&nbsp;B<sub>1</sub><sub>2</sub>&nbsp;and
+        its derivatives","number_indents":2,"heading":{"goods_nomenclature_sid":37433,"goods_nomenclature_item_id":"2936000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Provitamins
+        and vitamins, natural or reproduced by synthesis (including natural concentrates),
+        derivatives thereof used primarily as vitamins, and intermixtures of the foregoing,
+        whether or not in any solvent","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"69357","_score":1.0,"_source":{"id":69357,"goods_nomenclature_item_id":"3902100010","producline_suffix":"80","validity_start_date":"1998-01-01T00:00:00+00:00","validity_end_date":null,"description":"Polypropylene
         containing no plasticizer and not more than:<br/>- 7&nbsp;mg/kg of aluminium,<br/>-
         2&nbsp;mg/kg of iron,<br/>- 1&nbsp;mg/kg of magnesium,<br/>- 8&nbsp;mg/kg
         of chloride","number_indents":2,"heading":{"goods_nomenclature_sid":38687,"goods_nomenclature_item_id":"3902000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Polymers
@@ -2167,7 +2299,211 @@ http_interactions:
         hardened proteins, chemical derivatives of natural rubber), not elsewhere
         specified or included, in primary forms","number_indents":0},"chapter":{"goods_nomenclature_sid":38659,"goods_nomenclature_item_id":"3900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Plastics
         and articles thereof"},"section":{"numeral":"VII","title":"Plastics and articles
-        thereof; rubber and articles thereof","position":7}}},{"_index":"tariff-commodities","_type":"commodity","_id":"65642","_score":1.0,"_source":{"id":65642,"goods_nomenclature_item_id":"5603111020","producline_suffix":"80","validity_start_date":"1997-01-01T00:00:00+00:00","validity_end_date":null,"description":"Nonwovens,
+        thereof; rubber and articles thereof","position":7}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93976","_score":1.0,"_source":{"id":93976,"goods_nomenclature_item_id":"2933399937","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"Aqueous
+        solution of pyridine-2-thiol-1-oxide, sodium salt&nbsp;(CAS RN 3811-73-2)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"81615","_score":1.0,"_source":{"id":81615,"goods_nomenclature_item_id":"2933399940","producline_suffix":"80","validity_start_date":"2005-07-01T00:00:00+00:00","validity_end_date":null,"description":"2-chloropyridine
+        (CAS RN 109-09-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93975","_score":1.0,"_source":{"id":93975,"goods_nomenclature_item_id":"2933399942","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"2,2,6,6-Tetramethylpiperidine&nbsp;(CAS
+        RN 768-66-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97879","_score":1.0,"_source":{"id":97879,"goods_nomenclature_item_id":"2933399953","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"3-Bromopyridine
+        (CAS RN 626-55-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91435","_score":1.0,"_source":{"id":91435,"goods_nomenclature_item_id":"2933399955","producline_suffix":"80","validity_start_date":"2010-01-01T00:00:00+00:00","validity_end_date":null,"description":"Pyriproxyfen
+        (ISO) of a purity by weight of 97% or more (CAS RN 95737-68-1)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96341","_score":1.0,"_source":{"id":96341,"goods_nomenclature_item_id":"2933399972","producline_suffix":"80","validity_start_date":"2012-07-01T00:00:00+00:00","validity_end_date":null,"description":"5,6-Dimethoxy-2-[(4-piperidinyl)methyl]indan-1-one,
+        (CAS RN 120014-30-4)","number_indents":4,"heading":{"goods_nomenclature_sid":37193,"goods_nomenclature_item_id":"2933000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Heterocyclic
+        compounds with nitrogen hetero-atom(s) only; nucleic acids and their salts","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
+        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
+        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"88920","_score":1.0,"_source":{"id":88920,"goods_nomenclature_item_id":"6902900010","producline_suffix":"80","validity_start_date":"2008-01-01T00:00:00+00:00","validity_end_date":null,"description":"Refractory
+        bricks with<br/>- an edge length of more than 300 mm and<br/>- a TiO<sub>2</sub>
+        content of not more than 1% by weight and <br/>- a Al<sub>2</sub>O<sub>3</sub>
+        content of not more than 0.4% by weight and <br/>- a change in volume of less
+        than 9% at 1700\u00b0C","number_indents":2,"heading":{"goods_nomenclature_sid":44315,"goods_nomenclature_item_id":"6902000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Refractory
+        bricks, blocks, tiles and similar refractory ceramic constructional goods,
+        other than those of siliceous fossil meals or similar siliceous earths","number_indents":0},"chapter":{"goods_nomenclature_sid":44310,"goods_nomenclature_item_id":"6900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Ceramic
+        products"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
+        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96911","_score":1.0,"_source":{"id":96911,"goods_nomenclature_item_id":"6909190015","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"Ceramic
+        ring with rectangular transversal section having an external diameter of 19&nbsp;mm
+        or more (+&nbsp;0,00&nbsp;mm/-&nbsp;0,10&nbsp;mm) but not more than 29&nbsp;mm
+        (+ 0,00&nbsp;mm/-&nbsp;0,20&nbsp;mm), an internal diameter of 10&nbsp;mm or
+        more (+&nbsp;0,00&nbsp;mm/- 0,20&nbsp;mm) but not more than 19&nbsp;mm (+
+        0,00&nbsp;mm/-0,30&nbsp;mm), a thickness variable from 2&nbsp;mm (\u00b1&nbsp;0,10&nbsp;mm)
+        to 3,70&nbsp;mm (\u00b1 0,20&nbsp;mm) and heat resistance 240&nbsp;\u00b0C
+        or more, containing by weight:<br/>-&nbsp;90% (\u00b1&nbsp;1,5%) of aluminium
+        oxide<br/>-&nbsp;7% (\u00b1&nbsp;1%) of titanium oxide","number_indents":3,"heading":{"goods_nomenclature_sid":44372,"goods_nomenclature_item_id":"6909000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Ceramic
+        wares for laboratory, chemical or other technical uses; ceramic troughs, tubs
+        and similar receptacles of a kind used in agriculture; ceramic pots, jars
+        and similar articles of a kind used for the conveyance or packing of goods","number_indents":0},"chapter":{"goods_nomenclature_sid":44310,"goods_nomenclature_item_id":"6900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Ceramic
+        products"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
+        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93584","_score":1.0,"_source":{"id":93584,"goods_nomenclature_item_id":"7009910010","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"Unframed
+        glass mirrors with: <br/>-&nbsp;a length of 1516&nbsp;(\u00b1&nbsp;1&nbsp;mm);
+        <br/>-&nbsp;a width of 553&nbsp;(\u00b1&nbsp;1&nbsp;mm); <br/>-&nbsp;a thickness
+        of 3&nbsp;(\u00b1 0.1&nbsp;mm); <br/>-&nbsp;the back of the mirror covered
+        with protective polyethylene (PE) film, with a thickness of 0,11&nbsp;mm or
+        more but not more than&nbsp;0,13&nbsp;mm; <br/>-&nbsp;a lead content of not
+        more than 90&nbsp;mg/kg and <br/>-&nbsp;a corrosion resistance of 72&nbsp;hours
+        or more according to ISO&nbsp;9227&nbsp;salt spray test","number_indents":3,"heading":{"goods_nomenclature_sid":44517,"goods_nomenclature_item_id":"7009000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Glass
+        mirrors, whether or not framed, including rear-view mirrors","number_indents":0},"chapter":{"goods_nomenclature_sid":44408,"goods_nomenclature_item_id":"7000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Glass
+        and glassware"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
+        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"74013","_score":1.0,"_source":{"id":74013,"goods_nomenclature_item_id":"7010904100","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+00:00","validity_end_date":null,"description":"1&nbsp;l
+        or more","number_indents":8,"heading":{"goods_nomenclature_sid":44522,"goods_nomenclature_item_id":"7010000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Carboys,
+        bottles, flasks, jars, pots, phials, ampoules and other containers, of glass,
+        of a kind used for the conveyance or packing of goods; preserving jars of
+        glass; stoppers, lids and other closures, of glass","number_indents":0},"chapter":{"goods_nomenclature_sid":44408,"goods_nomenclature_item_id":"7000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Glass
+        and glassware"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
+        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"74014","_score":1.0,"_source":{"id":74014,"goods_nomenclature_item_id":"7010904300","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+00:00","validity_end_date":null,"description":"More
+        than 0,33&nbsp;l but less than 1&nbsp;l","number_indents":8,"heading":{"goods_nomenclature_sid":44522,"goods_nomenclature_item_id":"7010000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Carboys,
+        bottles, flasks, jars, pots, phials, ampoules and other containers, of glass,
+        of a kind used for the conveyance or packing of goods; preserving jars of
+        glass; stoppers, lids and other closures, of glass","number_indents":0},"chapter":{"goods_nomenclature_sid":44408,"goods_nomenclature_item_id":"7000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Glass
+        and glassware"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
+        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"74022","_score":1.0,"_source":{"id":74022,"goods_nomenclature_item_id":"7010905100","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+00:00","validity_end_date":null,"description":"1&nbsp;l
+        or more","number_indents":8,"heading":{"goods_nomenclature_sid":44522,"goods_nomenclature_item_id":"7010000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Carboys,
+        bottles, flasks, jars, pots, phials, ampoules and other containers, of glass,
+        of a kind used for the conveyance or packing of goods; preserving jars of
+        glass; stoppers, lids and other closures, of glass","number_indents":0},"chapter":{"goods_nomenclature_sid":44408,"goods_nomenclature_item_id":"7000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Glass
+        and glassware"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
+        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"74023","_score":1.0,"_source":{"id":74023,"goods_nomenclature_item_id":"7010905300","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+00:00","validity_end_date":null,"description":"More
+        than 0,33&nbsp;l but less than 1&nbsp;l","number_indents":8,"heading":{"goods_nomenclature_sid":44522,"goods_nomenclature_item_id":"7010000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Carboys,
+        bottles, flasks, jars, pots, phials, ampoules and other containers, of glass,
+        of a kind used for the conveyance or packing of goods; preserving jars of
+        glass; stoppers, lids and other closures, of glass","number_indents":0},"chapter":{"goods_nomenclature_sid":44408,"goods_nomenclature_item_id":"7000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Glass
+        and glassware"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
+        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"44631","_score":1.0,"_source":{"id":44631,"goods_nomenclature_item_id":"7018200000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Glass
+        microspheres not exceeding 1&nbsp;mm in diameter","number_indents":1,"heading":{"goods_nomenclature_sid":44621,"goods_nomenclature_item_id":"7018000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Glass
+        beads, imitation pearls, imitation precious or semi-precious stones and similar
+        glass smallwares, and articles thereof other than imitation jewellery; glass
+        eyes other than prosthetic articles; statuettes and other ornaments of lamp-worked
+        glass, other than imitation jewellery; glass microspheres not exceeding 1&nbsp;mm
+        in diameter","number_indents":0},"chapter":{"goods_nomenclature_sid":44408,"goods_nomenclature_item_id":"7000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Glass
+        and glassware"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
+        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96915","_score":1.0,"_source":{"id":96915,"goods_nomenclature_item_id":"7019120005","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"Rovings
+        ranging from 1&nbsp;980&nbsp;to 2&nbsp;033&nbsp;tex, composed of continuous
+        glass filaments of 9&nbsp;\u03bcm (\u00b1&nbsp;0,5&nbsp;\u00b5m)","number_indents":4,"heading":{"goods_nomenclature_sid":44635,"goods_nomenclature_item_id":"7019000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Glass
+        fibres (including glass wool) and articles thereof (for example, yarn, woven
+        fabrics)","number_indents":0},"chapter":{"goods_nomenclature_sid":44408,"goods_nomenclature_item_id":"7000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Glass
+        and glassware"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
+        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96916","_score":1.0,"_source":{"id":96916,"goods_nomenclature_item_id":"7019120025","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"Rovings
+        ranging from 1&nbsp;980&nbsp;to 2&nbsp;033&nbsp;tex, composed of continuous
+        glass filaments of 9&nbsp;\u03bcm (\u00b1&nbsp;0,5&nbsp;\u00b5m)","number_indents":4,"heading":{"goods_nomenclature_sid":44635,"goods_nomenclature_item_id":"7019000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Glass
+        fibres (including glass wool) and articles thereof (for example, yarn, woven
+        fabrics)","number_indents":0},"chapter":{"goods_nomenclature_sid":44408,"goods_nomenclature_item_id":"7000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Glass
+        and glassware"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
+        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96912","_score":1.0,"_source":{"id":96912,"goods_nomenclature_item_id":"7019191015","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"S-glass
+        yarn of 33 tex or a multiple of 33 tex (\u00b1 13%) made from continuous spun-glass
+        filaments with fibres of a diameter of 9 \u00b5m (- 1 \u00b5m / + 1,5 \u00b5m)","number_indents":4,"heading":{"goods_nomenclature_sid":44635,"goods_nomenclature_item_id":"7019000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Glass
+        fibres (including glass wool) and articles thereof (for example, yarn, woven
+        fabrics)","number_indents":0},"chapter":{"goods_nomenclature_sid":44408,"goods_nomenclature_item_id":"7000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Glass
+        and glassware"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
+        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"44815","_score":1.0,"_source":{"id":44815,"goods_nomenclature_item_id":"7201101100","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
+        by weight 1% or less of silicon","number_indents":3,"heading":{"goods_nomenclature_sid":44812,"goods_nomenclature_item_id":"7201000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Pig
+        iron and spiegeleisen in pigs, blocks or other primary forms","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
+        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
+        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"44816","_score":1.0,"_source":{"id":44816,"goods_nomenclature_item_id":"7201101900","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
+        by weight more than 1% of silicon","number_indents":3,"heading":{"goods_nomenclature_sid":44812,"goods_nomenclature_item_id":"7201000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Pig
+        iron and spiegeleisen in pigs, blocks or other primary forms","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
+        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
+        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"86539","_score":1.0,"_source":{"id":86539,"goods_nomenclature_item_id":"7201103010","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"Pig
+        iron ingots with a length of not more than 350&nbsp;mm, a width of not more
+        than 150&nbsp;mm, a height of not more than 150&nbsp;mm, containing by weight
+        not more than 1% of silicon","number_indents":3,"heading":{"goods_nomenclature_sid":44812,"goods_nomenclature_item_id":"7201000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Pig
+        iron and spiegeleisen in pigs, blocks or other primary forms","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
+        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
+        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"60034","_score":1.0,"_source":{"id":60034,"goods_nomenclature_item_id":"7201501000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Alloy
+        pig iron containing by weight not less than 0,3% but not more than 1% of titanium
+        and not less than 0,5% but not more than 1% of vanadium","number_indents":2,"heading":{"goods_nomenclature_sid":44812,"goods_nomenclature_item_id":"7201000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Pig
+        iron and spiegeleisen in pigs, blocks or other primary forms","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
+        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
+        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95638","_score":1.0,"_source":{"id":95638,"goods_nomenclature_item_id":"4810130020","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
+        a weight of 70&nbsp;g/m2 or more but not more than 400&nbsp;g/m2 and brightness
+        of more than 84 (measured according to ISO 2470-1), excluding multi-ply paper
+        and multi-ply paperboard and excluding rolls suitable for use in web-fed presses","number_indents":3,"heading":{"goods_nomenclature_sid":40591,"goods_nomenclature_item_id":"4810000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Paper
+        and paperboard, coated on one or both sides with kaolin (China clay) or other
+        inorganic substances, with or without a binder, and with no other coating,
+        whether or not surface-coloured, surface-decorated or printed, in rolls or
+        sheets","number_indents":0},"chapter":{"goods_nomenclature_sid":40400,"goods_nomenclature_item_id":"4800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Paper
+        and paperboard; articles of paper pulp, of paper or of paperboard"},"section":{"numeral":"X","title":"Pulp
+        of wood or of other fibrous cellulosic material; recovered (waste and scrap)
+        paper or paperboard; paper and paperboard and articles thereof","position":10}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95667","_score":1.0,"_source":{"id":95667,"goods_nomenclature_item_id":"4810140020","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
+        a weight of 70&nbsp;g/m2 or more but not more than 400&nbsp;g/m2 and brightness
+        of more than 84 (measured according to ISO 2470-1), excluding multi-ply paper
+        and multi-ply paperboard","number_indents":3,"heading":{"goods_nomenclature_sid":40591,"goods_nomenclature_item_id":"4810000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Paper
+        and paperboard, coated on one or both sides with kaolin (China clay) or other
+        inorganic substances, with or without a binder, and with no other coating,
+        whether or not surface-coloured, surface-decorated or printed, in rolls or
+        sheets","number_indents":0},"chapter":{"goods_nomenclature_sid":40400,"goods_nomenclature_item_id":"4800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Paper
+        and paperboard; articles of paper pulp, of paper or of paperboard"},"section":{"numeral":"X","title":"Pulp
+        of wood or of other fibrous cellulosic material; recovered (waste and scrap)
+        paper or paperboard; paper and paperboard and articles thereof","position":10}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95670","_score":1.0,"_source":{"id":95670,"goods_nomenclature_item_id":"4810190020","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
+        a weight of 70&nbsp;g/m2 or more but not more than 400&nbsp;g/m2 and brightness
+        of more than 84 (measured according to ISO 2470-1), excluding multi-ply paper
+        and multi-ply paperboard","number_indents":3,"heading":{"goods_nomenclature_sid":40591,"goods_nomenclature_item_id":"4810000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Paper
+        and paperboard, coated on one or both sides with kaolin (China clay) or other
+        inorganic substances, with or without a binder, and with no other coating,
+        whether or not surface-coloured, surface-decorated or printed, in rolls or
+        sheets","number_indents":0},"chapter":{"goods_nomenclature_sid":40400,"goods_nomenclature_item_id":"4800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Paper
+        and paperboard; articles of paper pulp, of paper or of paperboard"},"section":{"numeral":"X","title":"Pulp
+        of wood or of other fibrous cellulosic material; recovered (waste and scrap)
+        paper or paperboard; paper and paperboard and articles thereof","position":10}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95672","_score":1.0,"_source":{"id":95672,"goods_nomenclature_item_id":"4810220020","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
+        a weight of 70&nbsp;g/m2 or more but not more than 400&nbsp;g/m2 and brightness
+        of more than 84 (measured according to ISO 2470-1), excluding multi-ply paper
+        and multi-ply paperboard and excluding rolls suitable for use in web-fed presses","number_indents":3,"heading":{"goods_nomenclature_sid":40591,"goods_nomenclature_item_id":"4810000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Paper
+        and paperboard, coated on one or both sides with kaolin (China clay) or other
+        inorganic substances, with or without a binder, and with no other coating,
+        whether or not surface-coloured, surface-decorated or printed, in rolls or
+        sheets","number_indents":0},"chapter":{"goods_nomenclature_sid":40400,"goods_nomenclature_item_id":"4800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Paper
+        and paperboard; articles of paper pulp, of paper or of paperboard"},"section":{"numeral":"X","title":"Pulp
+        of wood or of other fibrous cellulosic material; recovered (waste and scrap)
+        paper or paperboard; paper and paperboard and articles thereof","position":10}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93463","_score":1.0,"_source":{"id":93463,"goods_nomenclature_item_id":"4810293020","producline_suffix":"80","validity_start_date":"2010-11-18T00:00:00+00:00","validity_end_date":null,"description":"With
+        a weight of 70&nbsp;g/m2 or more but not more than 400&nbsp;g/m2 and brightness
+        of more than 84 (measured according to ISO 2470-1), excluding multi-ply paper
+        and multi-ply paperboard and excluding rolls suitable for use in web-fed presses","number_indents":4,"heading":{"goods_nomenclature_sid":40591,"goods_nomenclature_item_id":"4810000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Paper
+        and paperboard, coated on one or both sides with kaolin (China clay) or other
+        inorganic substances, with or without a binder, and with no other coating,
+        whether or not surface-coloured, surface-decorated or printed, in rolls or
+        sheets","number_indents":0},"chapter":{"goods_nomenclature_sid":40400,"goods_nomenclature_item_id":"4800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Paper
+        and paperboard; articles of paper pulp, of paper or of paperboard"},"section":{"numeral":"X","title":"Pulp
+        of wood or of other fibrous cellulosic material; recovered (waste and scrap)
+        paper or paperboard; paper and paperboard and articles thereof","position":10}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93464","_score":1.0,"_source":{"id":93464,"goods_nomenclature_item_id":"4810298020","producline_suffix":"80","validity_start_date":"2010-11-18T00:00:00+00:00","validity_end_date":null,"description":"With
+        a weight of 70&nbsp;g/m2 or more but not more than 400&nbsp;g/m2 and brightness
+        of more than 84 (measured according to ISO 2470-1), excluding multi-ply paper
+        and multi-ply paperboard","number_indents":4,"heading":{"goods_nomenclature_sid":40591,"goods_nomenclature_item_id":"4810000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Paper
+        and paperboard, coated on one or both sides with kaolin (China clay) or other
+        inorganic substances, with or without a binder, and with no other coating,
+        whether or not surface-coloured, surface-decorated or printed, in rolls or
+        sheets","number_indents":0},"chapter":{"goods_nomenclature_sid":40400,"goods_nomenclature_item_id":"4800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Paper
+        and paperboard; articles of paper pulp, of paper or of paperboard"},"section":{"numeral":"X","title":"Pulp
+        of wood or of other fibrous cellulosic material; recovered (waste and scrap)
+        paper or paperboard; paper and paperboard and articles thereof","position":10}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93465","_score":1.0,"_source":{"id":93465,"goods_nomenclature_item_id":"4810991020","producline_suffix":"80","validity_start_date":"2010-11-18T00:00:00+00:00","validity_end_date":null,"description":"With
+        a weight of 70&nbsp;g/m2 or more but not more than 400&nbsp;g/m2 and brightness
+        of more than 84 (measured according to ISO 2470-1), excluding rolls suitable
+        for use in web-fed presses","number_indents":4,"heading":{"goods_nomenclature_sid":40591,"goods_nomenclature_item_id":"4810000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Paper
+        and paperboard, coated on one or both sides with kaolin (China clay) or other
+        inorganic substances, with or without a binder, and with no other coating,
+        whether or not surface-coloured, surface-decorated or printed, in rolls or
+        sheets","number_indents":0},"chapter":{"goods_nomenclature_sid":40400,"goods_nomenclature_item_id":"4800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Paper
+        and paperboard; articles of paper pulp, of paper or of paperboard"},"section":{"numeral":"X","title":"Pulp
+        of wood or of other fibrous cellulosic material; recovered (waste and scrap)
+        paper or paperboard; paper and paperboard and articles thereof","position":10}}},{"_index":"tariff-commodities","_type":"commodity","_id":"95676","_score":1.0,"_source":{"id":95676,"goods_nomenclature_item_id":"4810998020","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
+        a weight of 70&nbsp;g/m2 or more but not more than 400&nbsp;g/m2 and brightness
+        of more than 84 (measured according to ISO 2470-1), excluding rolls suitable
+        for use in web-fed presses","number_indents":4,"heading":{"goods_nomenclature_sid":40591,"goods_nomenclature_item_id":"4810000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Paper
+        and paperboard, coated on one or both sides with kaolin (China clay) or other
+        inorganic substances, with or without a binder, and with no other coating,
+        whether or not surface-coloured, surface-decorated or printed, in rolls or
+        sheets","number_indents":0},"chapter":{"goods_nomenclature_sid":40400,"goods_nomenclature_item_id":"4800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Paper
+        and paperboard; articles of paper pulp, of paper or of paperboard"},"section":{"numeral":"X","title":"Pulp
+        of wood or of other fibrous cellulosic material; recovered (waste and scrap)
+        paper or paperboard; paper and paperboard and articles thereof","position":10}}},{"_index":"tariff-commodities","_type":"commodity","_id":"65642","_score":1.0,"_source":{"id":65642,"goods_nomenclature_item_id":"5603111020","producline_suffix":"80","validity_start_date":"1997-01-01T00:00:00+00:00","validity_end_date":null,"description":"Nonwovens,
         not weighing more than 20&nbsp;g/m<sup>2</sup>, containing spunbonded and
         meltblown filaments put together in a sandwich way with the two outer layers
         containing fine endless filaments (not less than 10&nbsp;\u00b5m but not more
@@ -2211,7 +2547,78 @@ http_interactions:
         of cotton, of a width of less than 1&nbsp;500&nbsp;mm","number_indents":3,"heading":{"goods_nomenclature_sid":42492,"goods_nomenclature_item_id":"5803000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Gauze,
         other than narrow fabrics of heading&nbsp;5806","number_indents":0},"chapter":{"goods_nomenclature_sid":42449,"goods_nomenclature_item_id":"5800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Special
         woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery"},"section":{"numeral":"XI","title":"Textiles
-        and textile articles","position":11}}},{"_index":"tariff-commodities","_type":"commodity","_id":"88114","_score":1.0,"_source":{"id":88114,"goods_nomenclature_item_id":"5402470010","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"Synthetic
+        and textile articles","position":11}}},{"_index":"tariff-commodities","_type":"commodity","_id":"43122","_score":1.0,"_source":{"id":43122,"goods_nomenclature_item_id":"6201121000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a weight, per garment, not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":43116,"goods_nomenclature_item_id":"6201000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Men''s
+        or boys'' overcoats, car coats, capes, cloaks, anoraks (including ski jackets),
+        windcheaters, wind-jackets and similar articles, other than those of heading&nbsp;6203","number_indents":0},"chapter":{"goods_nomenclature_sid":43115,"goods_nomenclature_item_id":"6200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Articles
+        of apparel and clothing accessories, not knitted or crocheted"},"section":{"numeral":"XI","title":"Textiles
+        and textile articles","position":11}}},{"_index":"tariff-commodities","_type":"commodity","_id":"43125","_score":1.0,"_source":{"id":43125,"goods_nomenclature_item_id":"6201129000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a weight, per garment, exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":43116,"goods_nomenclature_item_id":"6201000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Men''s
+        or boys'' overcoats, car coats, capes, cloaks, anoraks (including ski jackets),
+        windcheaters, wind-jackets and similar articles, other than those of heading&nbsp;6203","number_indents":0},"chapter":{"goods_nomenclature_sid":43115,"goods_nomenclature_item_id":"6200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Articles
+        of apparel and clothing accessories, not knitted or crocheted"},"section":{"numeral":"XI","title":"Textiles
+        and textile articles","position":11}}},{"_index":"tariff-commodities","_type":"commodity","_id":"43129","_score":1.0,"_source":{"id":43129,"goods_nomenclature_item_id":"6201131000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a weight, per garment, not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":43116,"goods_nomenclature_item_id":"6201000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Men''s
+        or boys'' overcoats, car coats, capes, cloaks, anoraks (including ski jackets),
+        windcheaters, wind-jackets and similar articles, other than those of heading&nbsp;6203","number_indents":0},"chapter":{"goods_nomenclature_sid":43115,"goods_nomenclature_item_id":"6200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Articles
+        of apparel and clothing accessories, not knitted or crocheted"},"section":{"numeral":"XI","title":"Textiles
+        and textile articles","position":11}}},{"_index":"tariff-commodities","_type":"commodity","_id":"43132","_score":1.0,"_source":{"id":43132,"goods_nomenclature_item_id":"6201139000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a weight, per garment, exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":43116,"goods_nomenclature_item_id":"6201000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Men''s
+        or boys'' overcoats, car coats, capes, cloaks, anoraks (including ski jackets),
+        windcheaters, wind-jackets and similar articles, other than those of heading&nbsp;6203","number_indents":0},"chapter":{"goods_nomenclature_sid":43115,"goods_nomenclature_item_id":"6200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Articles
+        of apparel and clothing accessories, not knitted or crocheted"},"section":{"numeral":"XI","title":"Textiles
+        and textile articles","position":11}}},{"_index":"tariff-commodities","_type":"commodity","_id":"43152","_score":1.0,"_source":{"id":43152,"goods_nomenclature_item_id":"6202121000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a weight, per garment, not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":43145,"goods_nomenclature_item_id":"6202000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Women''s
+        or girls'' overcoats, car coats, capes, cloaks, anoraks (including ski jackets),
+        windcheaters, wind-jackets and similar articles, other than those of heading&nbsp;6204","number_indents":0},"chapter":{"goods_nomenclature_sid":43115,"goods_nomenclature_item_id":"6200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Articles
+        of apparel and clothing accessories, not knitted or crocheted"},"section":{"numeral":"XI","title":"Textiles
+        and textile articles","position":11}}},{"_index":"tariff-commodities","_type":"commodity","_id":"43155","_score":1.0,"_source":{"id":43155,"goods_nomenclature_item_id":"6202129000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a weight, per garment, exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":43145,"goods_nomenclature_item_id":"6202000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Women''s
+        or girls'' overcoats, car coats, capes, cloaks, anoraks (including ski jackets),
+        windcheaters, wind-jackets and similar articles, other than those of heading&nbsp;6204","number_indents":0},"chapter":{"goods_nomenclature_sid":43115,"goods_nomenclature_item_id":"6200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Articles
+        of apparel and clothing accessories, not knitted or crocheted"},"section":{"numeral":"XI","title":"Textiles
+        and textile articles","position":11}}},{"_index":"tariff-commodities","_type":"commodity","_id":"43159","_score":1.0,"_source":{"id":43159,"goods_nomenclature_item_id":"6202131000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a weight, per garment, not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":43145,"goods_nomenclature_item_id":"6202000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Women''s
+        or girls'' overcoats, car coats, capes, cloaks, anoraks (including ski jackets),
+        windcheaters, wind-jackets and similar articles, other than those of heading&nbsp;6204","number_indents":0},"chapter":{"goods_nomenclature_sid":43115,"goods_nomenclature_item_id":"6200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Articles
+        of apparel and clothing accessories, not knitted or crocheted"},"section":{"numeral":"XI","title":"Textiles
+        and textile articles","position":11}}},{"_index":"tariff-commodities","_type":"commodity","_id":"43162","_score":1.0,"_source":{"id":43162,"goods_nomenclature_item_id":"6202139000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a weight, per garment, exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":43145,"goods_nomenclature_item_id":"6202000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Women''s
+        or girls'' overcoats, car coats, capes, cloaks, anoraks (including ski jackets),
+        windcheaters, wind-jackets and similar articles, other than those of heading&nbsp;6204","number_indents":0},"chapter":{"goods_nomenclature_sid":43115,"goods_nomenclature_item_id":"6200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Articles
+        of apparel and clothing accessories, not knitted or crocheted"},"section":{"numeral":"XI","title":"Textiles
+        and textile articles","position":11}}},{"_index":"tariff-commodities","_type":"commodity","_id":"80953","_score":1.0,"_source":{"id":80953,"goods_nomenclature_item_id":"7208521000","producline_suffix":"80","validity_start_date":"2005-01-01T00:00:00+00:00","validity_end_date":null,"description":"Rolled
+        on four faces or in a closed box pass, of a width not exceeding 1&nbsp;250&nbsp;mm","number_indents":3,"heading":{"goods_nomenclature_sid":44986,"goods_nomenclature_item_id":"7208000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Flat-rolled
+        products of iron or non-alloy steel, of a width of 600&nbsp;mm or more, hot-rolled,
+        not clad, plated or coated","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
+        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
+        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"80956","_score":1.0,"_source":{"id":80956,"goods_nomenclature_item_id":"7208531000","producline_suffix":"80","validity_start_date":"2005-01-01T00:00:00+00:00","validity_end_date":null,"description":"Rolled
+        on four faces or in a closed box pass, of a width not exceeding 1&nbsp;250&nbsp;mm
+        and of a thickness of 4&nbsp;mm or more","number_indents":3,"heading":{"goods_nomenclature_sid":44986,"goods_nomenclature_item_id":"7208000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Flat-rolled
+        products of iron or non-alloy steel, of a width of 600&nbsp;mm or more, hot-rolled,
+        not clad, plated or coated","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
+        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
+        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"60077","_score":1.0,"_source":{"id":60077,"goods_nomenclature_item_id":"7209160000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a thickness exceeding 1&nbsp;mm but less than 3&nbsp;mm","number_indents":2,"heading":{"goods_nomenclature_sid":45192,"goods_nomenclature_item_id":"7209000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Flat-rolled
+        products of iron or non-alloy steel, of a width of 600&nbsp;mm or more, cold-rolled
+        (cold-reduced), not clad, plated or coated","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
+        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
+        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"60080","_score":1.0,"_source":{"id":60080,"goods_nomenclature_item_id":"7209170000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a thickness of 0,5&nbsp;mm or more but not exceeding 1&nbsp;mm","number_indents":2,"heading":{"goods_nomenclature_sid":45192,"goods_nomenclature_item_id":"7209000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Flat-rolled
+        products of iron or non-alloy steel, of a width of 600&nbsp;mm or more, cold-rolled
+        (cold-reduced), not clad, plated or coated","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
+        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
+        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"60090","_score":1.0,"_source":{"id":60090,"goods_nomenclature_item_id":"7209260000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a thickness exceeding 1&nbsp;mm but less than 3&nbsp;mm","number_indents":2,"heading":{"goods_nomenclature_sid":45192,"goods_nomenclature_item_id":"7209000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Flat-rolled
+        products of iron or non-alloy steel, of a width of 600&nbsp;mm or more, cold-rolled
+        (cold-reduced), not clad, plated or coated","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
+        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
+        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"60093","_score":1.0,"_source":{"id":60093,"goods_nomenclature_item_id":"7209270000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a thickness of 0,5&nbsp;mm or more but not exceeding 1&nbsp;mm","number_indents":2,"heading":{"goods_nomenclature_sid":45192,"goods_nomenclature_item_id":"7209000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Flat-rolled
+        products of iron or non-alloy steel, of a width of 600&nbsp;mm or more, cold-rolled
+        (cold-reduced), not clad, plated or coated","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
+        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
+        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"88114","_score":1.0,"_source":{"id":88114,"goods_nomenclature_item_id":"5402470010","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"Synthetic
         bicomponent filament yarn, not textured, untwisted, measuring 1&nbsp;650&nbsp;decitex
         or more but not more than 1&nbsp;800&nbsp;decitex, consisting of 110&nbsp;filaments
         or more but not more than 120&nbsp;filaments, each having a core of poly(ethylene
@@ -2228,31 +2635,179 @@ http_interactions:
         for the manufacture of carbon-fibre yarn","number_indents":3,"heading":{"goods_nomenclature_sid":41711,"goods_nomenclature_item_id":"5402000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Synthetic
         filament yarn (other than sewing thread), not put up for retail sale, including
         synthetic monofilament of less than 67&nbsp;decitex","number_indents":0},"chapter":{"goods_nomenclature_sid":41701,"goods_nomenclature_item_id":"5400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Man-made
-        filaments"},"section":{"numeral":"XI","title":"Textiles and textile articles","position":11}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92656","_score":1.0,"_source":{"id":92656,"goods_nomenclature_item_id":"2922198540","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"2-(Dimethylamino)
-        ethyl benzoate (CAS RN 2208-05-1)","number_indents":4,"heading":{"goods_nomenclature_sid":36896,"goods_nomenclature_item_id":"2922000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Oxygen-function
-        amino-compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91599","_score":1.0,"_source":{"id":91599,"goods_nomenclature_item_id":"2922198570","producline_suffix":"80","validity_start_date":"2010-01-01T00:00:00+00:00","validity_end_date":null,"description":"D-(-)-threo-2-amino-1-(p-nitrophenyl)propane-1,3-diol
-        (CAS RN 716-61-0)","number_indents":4,"heading":{"goods_nomenclature_sid":36896,"goods_nomenclature_item_id":"2922000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Oxygen-function
-        amino-compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97950","_score":1.0,"_source":{"id":97950,"goods_nomenclature_item_id":"2922198585","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"(1S,4R)-cis-4-Amino-2-cyclopentene-1-methanol-D-tartrate
-        (CAS RN 229177-52-0)","number_indents":4,"heading":{"goods_nomenclature_sid":36896,"goods_nomenclature_item_id":"2922000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Oxygen-function
-        amino-compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"73239","_score":1.0,"_source":{"id":73239,"goods_nomenclature_item_id":"2922390010","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+00:00","validity_end_date":null,"description":"1-Amino-4-bromo-9,10-dioxoanthracene-2-sulfonic
-        acid and its salts","number_indents":3,"heading":{"goods_nomenclature_sid":36896,"goods_nomenclature_item_id":"2922000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Oxygen-function
-        amino-compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92657","_score":1.0,"_source":{"id":92657,"goods_nomenclature_item_id":"2922500020","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"1-[2-Amino-1-(4-methoxyphenyl)-ethyl]-cyclohexanol
-        hydrochloride (CAS RN 130198-05-9)","number_indents":2,"heading":{"goods_nomenclature_sid":36896,"goods_nomenclature_item_id":"2922000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Oxygen-function
-        amino-compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"76735","_score":1.0,"_source":{"id":76735,"goods_nomenclature_item_id":"2922500070","producline_suffix":"80","validity_start_date":"2003-07-01T00:00:00+00:00","validity_end_date":null,"description":"2-(1-Hydroxycyclohexyl)-2-(4-methoxyphenyl)ethylammonium
-        acetate","number_indents":2,"heading":{"goods_nomenclature_sid":36896,"goods_nomenclature_item_id":"2922000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Oxygen-function
-        amino-compounds","number_indents":0},"chapter":{"goods_nomenclature_sid":36168,"goods_nomenclature_item_id":"2900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        chemicals"},"section":{"numeral":"VI","title":"Products of the chemical or
-        allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"82633","_score":1.0,"_source":{"id":82633,"goods_nomenclature_item_id":"8507302030","producline_suffix":"80","validity_start_date":"2006-01-01T00:00:00+00:00","validity_end_date":null,"description":"Cylindrical
+        filaments"},"section":{"numeral":"XI","title":"Textiles and textile articles","position":11}}},{"_index":"tariff-commodities","_type":"commodity","_id":"45741","_score":1.0,"_source":{"id":45741,"goods_nomenclature_item_id":"7219330000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a thickness exceeding&nbsp;1&nbsp;mm but less than 3&nbsp;mm","number_indents":2,"heading":{"goods_nomenclature_sid":45704,"goods_nomenclature_item_id":"7219000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Flat-rolled
+        products of stainless steel, of a width of 600&nbsp;mm or more","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
+        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
+        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"45744","_score":1.0,"_source":{"id":45744,"goods_nomenclature_item_id":"7219340000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a thickness of 0,5&nbsp;mm or more but not exceeding&nbsp;1&nbsp;mm","number_indents":2,"heading":{"goods_nomenclature_sid":45704,"goods_nomenclature_item_id":"7219000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Flat-rolled
+        products of stainless steel, of a width of 600&nbsp;mm or more","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
+        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
+        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"45863","_score":1.0,"_source":{"id":45863,"goods_nomenclature_item_id":"7224900500","producline_suffix":"80","validity_start_date":"1993-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
+        by weight not more than 0,7% of carbon, 0,5% or more but not more than 1,2%
+        of manganese and 0,6% or more but not more than 2,3% of silicon; containing
+        by weight 0,0008% or more of boron with any other elements less than the minimum
+        content referred to in note 1 f) to this chapter","number_indents":5,"heading":{"goods_nomenclature_sid":45856,"goods_nomenclature_item_id":"7224000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        alloy steel in ingots or other primary forms; semi-finished products of other
+        alloy steel","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
+        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
+        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"48250","_score":1.0,"_source":{"id":48250,"goods_nomenclature_item_id":"8427101000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
+        a lifting height of 1&nbsp;m or more","number_indents":2,"heading":{"goods_nomenclature_sid":48248,"goods_nomenclature_item_id":"8427000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fork-lift
+        trucks; other works trucks fitted with lifting or handling equipment","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
+        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
+        and mechanical appliances; electrical equipment; parts thereof, sound recorders
+        and reproducers, television image and sound recorders and reproducers, and
+        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"48253","_score":1.0,"_source":{"id":48253,"goods_nomenclature_item_id":"8427201100","producline_suffix":"10","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
+        a lifting height of 1&nbsp;m or more","number_indents":2,"heading":{"goods_nomenclature_sid":48248,"goods_nomenclature_item_id":"8427000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fork-lift
+        trucks; other works trucks fitted with lifting or handling equipment","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
+        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
+        and mechanical appliances; electrical equipment; parts thereof, sound recorders
+        and reproducers, television image and sound recorders and reproducers, and
+        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"57611","_score":1.0,"_source":{"id":57611,"goods_nomenclature_item_id":"8408107100","producline_suffix":"10","validity_start_date":"1995-01-01T00:00:00+00:00","validity_end_date":null,"description":"Exceeding
+        500&nbsp;kW but not exceeding 1&nbsp;000&nbsp;kW","number_indents":3,"heading":{"goods_nomenclature_sid":47669,"goods_nomenclature_item_id":"8408000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Compression-ignition
+        internal combustion piston engines (diesel or semi-diesel engines)","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
+        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
+        and mechanical appliances; electrical equipment; parts thereof, sound recorders
+        and reproducers, television image and sound recorders and reproducers, and
+        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"57614","_score":1.0,"_source":{"id":57614,"goods_nomenclature_item_id":"8408108100","producline_suffix":"10","validity_start_date":"1995-01-01T00:00:00+00:00","validity_end_date":null,"description":"Exceeding
+        1&nbsp;000&nbsp;kW but not exceeding 5&nbsp;000&nbsp;kW","number_indents":3,"heading":{"goods_nomenclature_sid":47669,"goods_nomenclature_item_id":"8408000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Compression-ignition
+        internal combustion piston engines (diesel or semi-diesel engines)","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
+        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
+        and mechanical appliances; electrical equipment; parts thereof, sound recorders
+        and reproducers, television image and sound recorders and reproducers, and
+        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"82784","_score":1.0,"_source":{"id":82784,"goods_nomenclature_item_id":"8408908100","producline_suffix":"80","validity_start_date":"2006-01-01T00:00:00+00:00","validity_end_date":null,"description":"Exceeding
+        500&nbsp;kW but not exceeding 1&nbsp;000&nbsp;kW","number_indents":4,"heading":{"goods_nomenclature_sid":47669,"goods_nomenclature_item_id":"8408000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Compression-ignition
+        internal combustion piston engines (diesel or semi-diesel engines)","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
+        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
+        and mechanical appliances; electrical equipment; parts thereof, sound recorders
+        and reproducers, television image and sound recorders and reproducers, and
+        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"82787","_score":1.0,"_source":{"id":82787,"goods_nomenclature_item_id":"8408908500","producline_suffix":"80","validity_start_date":"2006-01-01T00:00:00+00:00","validity_end_date":null,"description":"Exceeding
+        1&nbsp;000&nbsp;kW but not exceeding 5&nbsp;000&nbsp;kW","number_indents":4,"heading":{"goods_nomenclature_sid":47669,"goods_nomenclature_item_id":"8408000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Compression-ignition
+        internal combustion piston engines (diesel or semi-diesel engines)","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
+        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
+        and mechanical appliances; electrical equipment; parts thereof, sound recorders
+        and reproducers, television image and sound recorders and reproducers, and
+        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"47743","_score":1.0,"_source":{"id":47743,"goods_nomenclature_item_id":"8410110000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a power not exceeding 1&nbsp;000&nbsp;kW","number_indents":2,"heading":{"goods_nomenclature_sid":47741,"goods_nomenclature_item_id":"8410000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Hydraulic
+        turbines, water wheels, and regulators therefor","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
+        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
+        and mechanical appliances; electrical equipment; parts thereof, sound recorders
+        and reproducers, television image and sound recorders and reproducers, and
+        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"47744","_score":1.0,"_source":{"id":47744,"goods_nomenclature_item_id":"8410120000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a power exceeding 1&nbsp;000&nbsp;kW but not exceeding 10&nbsp;000&nbsp;kW","number_indents":2,"heading":{"goods_nomenclature_sid":47741,"goods_nomenclature_item_id":"8410000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Hydraulic
+        turbines, water wheels, and regulators therefor","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
+        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
+        and mechanical appliances; electrical equipment; parts thereof, sound recorders
+        and reproducers, television image and sound recorders and reproducers, and
+        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"47765","_score":1.0,"_source":{"id":47765,"goods_nomenclature_item_id":"8411210000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a power not exceeding 1&nbsp;100&nbsp;kW","number_indents":2,"heading":{"goods_nomenclature_sid":47749,"goods_nomenclature_item_id":"8411000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Turbojets,
+        turbopropellers and other gas turbines","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
+        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
+        and mechanical appliances; electrical equipment; parts thereof, sound recorders
+        and reproducers, television image and sound recorders and reproducers, and
+        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"47770","_score":1.0,"_source":{"id":47770,"goods_nomenclature_item_id":"8411220000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a power exceeding 1&nbsp;100&nbsp;kW","number_indents":2,"heading":{"goods_nomenclature_sid":47749,"goods_nomenclature_item_id":"8411000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Turbojets,
+        turbopropellers and other gas turbines","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
+        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
+        and mechanical appliances; electrical equipment; parts thereof, sound recorders
+        and reproducers, television image and sound recorders and reproducers, and
+        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"82822","_score":1.0,"_source":{"id":82822,"goods_nomenclature_item_id":"8411222000","producline_suffix":"80","validity_start_date":"2006-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a power exceeding 1&nbsp;100&nbsp;kW but not exceeding 3&nbsp;730&nbsp;kW","number_indents":3,"heading":{"goods_nomenclature_sid":47749,"goods_nomenclature_item_id":"8411000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Turbojets,
+        turbopropellers and other gas turbines","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
+        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
+        and mechanical appliances; electrical equipment; parts thereof, sound recorders
+        and reproducers, television image and sound recorders and reproducers, and
+        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96925","_score":1.0,"_source":{"id":96925,"goods_nomenclature_item_id":"8411990030","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"Wheel-shaped
+        gas turbine component with blades, of a kind used in turbochargers:<br/>-&nbsp;of
+        a precision-cast nickel based alloy complying with standard DIN G- NiCr13Al16MoNb
+        or DIN NiCo10W10Cr9AlTi or AMS AISI:686,<br/>-&nbsp;with a heat-resistance
+        of not more than 1&nbsp;100&nbsp;\u00b0C;<br/>-&nbsp;with a diameter of 30&nbsp;mm
+        or more, but not more than 80&nbsp;mm;<br/>-&nbsp;with a height of 30&nbsp;mm
+        or more, but not more than 50&nbsp;mm","number_indents":4,"heading":{"goods_nomenclature_sid":47749,"goods_nomenclature_item_id":"8411000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Turbojets,
+        turbopropellers and other gas turbines","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
+        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
+        and mechanical appliances; electrical equipment; parts thereof, sound recorders
+        and reproducers, television image and sound recorders and reproducers, and
+        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"98051","_score":1.0,"_source":{"id":98051,"goods_nomenclature_item_id":"8411990040","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"Spiral-shaped
+        gas turbine turbocharger component:<br/>-&nbsp;of a stainless alloy,<br/>-&nbsp;with
+        a heat-resistance of not more than 1&nbsp;050&nbsp;\u00b0C,<br/>-&nbsp;with
+        a diameter of 100&nbsp;mm or more, but not more than 200&nbsp;mm,<br/>-&nbsp;with
+        a height of 100&nbsp;mm or more, but not more than 150&nbsp;mm,<br/>-&nbsp;whether
+        or not with an engine exhaust manifold","number_indents":4,"heading":{"goods_nomenclature_sid":47749,"goods_nomenclature_item_id":"8411000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Turbojets,
+        turbopropellers and other gas turbines","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
+        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
+        and mechanical appliances; electrical equipment; parts thereof, sound recorders
+        and reproducers, television image and sound recorders and reproducers, and
+        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"86553","_score":1.0,"_source":{"id":86553,"goods_nomenclature_item_id":"8414900050","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"Cross-flow
+        fan, of 97.4&nbsp;mm (\u00b1&nbsp;0.2&nbsp;mm) diameter and 645&nbsp;mm (\u00b11&nbsp;mm)
+        or 873&nbsp;mm (+0.5/-1&nbsp;mm) height made from anti-static, anti-bacterial
+        and heat-resistant, glass fiber reinforced plastic with a minimum temperature
+        resistance of 70&nbsp;\u00b0C, for use in the manufacture of indoor air conditioning
+        units","number_indents":2,"heading":{"goods_nomenclature_sid":47902,"goods_nomenclature_item_id":"8414000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Air
+        or vacuum pumps, air or other gas compressors and fans; ventilating or recycling
+        hoods incorporating a fan, whether or not fitted with filters","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
+        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
+        and mechanical appliances; electrical equipment; parts thereof, sound recorders
+        and reproducers, television image and sound recorders and reproducers, and
+        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"86957","_score":1.0,"_source":{"id":86957,"goods_nomenclature_item_id":"7419999091","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"Disc
+        (target) with deposition material, consisting of molybdenum silicide:<br/>-
+        containing 1&nbsp;mg/kg or less of sodium<br/>and<br/>- mounted on a copper
+        or aluminium support","number_indents":5,"heading":{"goods_nomenclature_sid":46883,"goods_nomenclature_item_id":"7419000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        articles of copper","number_indents":0},"chapter":{"goods_nomenclature_sid":46740,"goods_nomenclature_item_id":"7400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Copper
+        and articles thereof"},"section":{"numeral":"XV","title":"Base metals and
+        articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93091","_score":1.0,"_source":{"id":93091,"goods_nomenclature_item_id":"7606129220","producline_suffix":"80","validity_start_date":"2011-01-01T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
+        and magnesium alloy strip:<br/>-&nbsp;in rolls,<br/>-&nbsp;of a thickness
+        of 0,14&nbsp;mm or more but not more than 0,40&nbsp;mm,<br/>-&nbsp;a width
+        of 12,5&nbsp;mm or more but not more than 359&nbsp;mm,<br/>-&nbsp;a tensile
+        strength of 285&nbsp;N/mm<sup>2</sup>&nbsp;or more, and<br/>-&nbsp;an elongation
+        at break of 1% or more, and<br/>containing by weight:<br/>-&nbsp;93,3% or
+        more of aluminium,<br/>-&nbsp;2,2% or more but not more than 5% of magnesium,
+        and<br/>-&nbsp;not more than 1,8% of other elements","number_indents":5,"heading":{"goods_nomenclature_sid":46965,"goods_nomenclature_item_id":"7606000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
+        plates, sheets and strip, of a thickness exceeding 0,2&nbsp;mm","number_indents":0},"chapter":{"goods_nomenclature_sid":46925,"goods_nomenclature_item_id":"7600000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
+        and articles thereof"},"section":{"numeral":"XV","title":"Base metals and
+        articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"82694","_score":1.0,"_source":{"id":82694,"goods_nomenclature_item_id":"8522904950","producline_suffix":"80","validity_start_date":"2006-01-01T00:00:00+00:00","validity_end_date":null,"description":"Electronic
+        assembly for a laser read-head of a compact disc player, comprising:<br/>-
+        a printed circuit,<br/>- a photo-detector, in the form of a monolithic integrated
+        circuit, contained in a housing,<br/>- not more than 3 connectors,<br/>- not
+        more than 1 transistor,<br/>- not more than 3 variable and 4 fixed resistors,<br/>-
+        not more than 5 capacitors,the whole mounted on a support","number_indents":5,"heading":{"goods_nomenclature_sid":50201,"goods_nomenclature_item_id":"8522000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Parts
+        and accessories of apparatus of headings Nos  8519&nbsp;to  8521","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        machinery and equipment and parts thereof; sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
+        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"76694","_score":1.0,"_source":{"id":76694,"goods_nomenclature_item_id":"8309909010","producline_suffix":"80","validity_start_date":"2003-07-01T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
+        can ends with so-called \"ring pull\" full aperture with a diameter of 136,5&nbsp;mm&nbsp;(+/-&nbsp;1&nbsp;mm)","number_indents":3,"heading":{"goods_nomenclature_sid":47558,"goods_nomenclature_item_id":"8309000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Stoppers,
+        caps and lids (including crown corks, screw caps and pouring stoppers), capsules
+        for bottles, threaded bungs, bung covers, seals and other packing accessories,
+        of base metal","number_indents":0},"chapter":{"goods_nomenclature_sid":47491,"goods_nomenclature_item_id":"8300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
+        articles of base metal"},"section":{"numeral":"XV","title":"Base metals and
+        articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"47649","_score":1.0,"_source":{"id":47649,"goods_nomenclature_item_id":"8407330000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a cylinder capacity exceeding&nbsp;250&nbsp;cc but not exceeding&nbsp;1&nbsp;000&nbsp;cc","number_indents":2,"heading":{"goods_nomenclature_sid":47621,"goods_nomenclature_item_id":"8407000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Spark-ignition
+        reciprocating or rotary internal combustion piston engines","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
+        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
+        and mechanical appliances; electrical equipment; parts thereof, sound recorders
+        and reproducers, television image and sound recorders and reproducers, and
+        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"47652","_score":1.0,"_source":{"id":47652,"goods_nomenclature_item_id":"8407340000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
+        a cylinder capacity exceeding 1&nbsp;000&nbsp;cm<sup>3</sup>","number_indents":2,"heading":{"goods_nomenclature_sid":47621,"goods_nomenclature_item_id":"8407000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Spark-ignition
+        reciprocating or rotary internal combustion piston engines","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
+        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
+        and mechanical appliances; electrical equipment; parts thereof, sound recorders
+        and reproducers, television image and sound recorders and reproducers, and
+        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"47657","_score":1.0,"_source":{"id":47657,"goods_nomenclature_item_id":"8407349100","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Not
+        exceeding 1&nbsp;500&nbsp;cm<sup>3</sup>","number_indents":5,"heading":{"goods_nomenclature_sid":47621,"goods_nomenclature_item_id":"8407000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Spark-ignition
+        reciprocating or rotary internal combustion piston engines","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
+        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
+        and mechanical appliances; electrical equipment; parts thereof, sound recorders
+        and reproducers, television image and sound recorders and reproducers, and
+        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"47658","_score":1.0,"_source":{"id":47658,"goods_nomenclature_item_id":"8407349900","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Exceeding
+        1&nbsp;500&nbsp;cm<sup>3</sup>","number_indents":5,"heading":{"goods_nomenclature_sid":47621,"goods_nomenclature_item_id":"8407000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Spark-ignition
+        reciprocating or rotary internal combustion piston engines","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
+        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
+        and mechanical appliances; electrical equipment; parts thereof, sound recorders
+        and reproducers, television image and sound recorders and reproducers, and
+        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"82633","_score":1.0,"_source":{"id":82633,"goods_nomenclature_item_id":"8507302030","producline_suffix":"80","validity_start_date":"2006-01-01T00:00:00+00:00","validity_end_date":null,"description":"Cylindrical
         nickel-cadmium accumulator, with a length of 65,3 mm (+/-1,5 mm) and a diameter
         of 14,5 mm (+/-1 mm), having a nominal capacity of 1&nbsp;000 mAh or more,
         for use in the manufacture of rechargeable batteries","number_indents":3,"heading":{"goods_nomenclature_sid":49833,"goods_nomenclature_item_id":"8507000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Electric
@@ -2340,13 +2895,340 @@ http_interactions:
         of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
         appliances; electrical equipment; parts thereof, sound recorders and reproducers,
         television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"82694","_score":1.0,"_source":{"id":82694,"goods_nomenclature_item_id":"8522904950","producline_suffix":"80","validity_start_date":"2006-01-01T00:00:00+00:00","validity_end_date":null,"description":"Electronic
-        assembly for a laser read-head of a compact disc player, comprising:<br/>-
-        a printed circuit,<br/>- a photo-detector, in the form of a monolithic integrated
-        circuit, contained in a housing,<br/>- not more than 3 connectors,<br/>- not
-        more than 1 transistor,<br/>- not more than 3 variable and 4 fixed resistors,<br/>-
-        not more than 5 capacitors,the whole mounted on a support","number_indents":5,"heading":{"goods_nomenclature_sid":50201,"goods_nomenclature_item_id":"8522000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Parts
-        and accessories of apparatus of headings Nos  8519&nbsp;to  8521","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"46329","_score":1.0,"_source":{"id":46329,"goods_nomenclature_item_id":"7311009100","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Less
+        than 1&nbsp;000&nbsp;l","number_indents":2,"heading":{"goods_nomenclature_sid":46324,"goods_nomenclature_item_id":"7311000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containers
+        for compressed or liquefied gas, of iron or steel","number_indents":0},"chapter":{"goods_nomenclature_sid":46039,"goods_nomenclature_item_id":"7300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Articles
+        of iron or steel"},"section":{"numeral":"XV","title":"Base metals and articles
+        of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"46330","_score":1.0,"_source":{"id":46330,"goods_nomenclature_item_id":"7311009900","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"1&nbsp;000&nbsp;l
+        or more","number_indents":2,"heading":{"goods_nomenclature_sid":46324,"goods_nomenclature_item_id":"7311000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containers
+        for compressed or liquefied gas, of iron or steel","number_indents":0},"chapter":{"goods_nomenclature_sid":46039,"goods_nomenclature_item_id":"7300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Articles
+        of iron or steel"},"section":{"numeral":"XV","title":"Base metals and articles
+        of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90044","_score":1.0,"_source":{"id":90044,"goods_nomenclature_item_id":"7607119020","producline_suffix":"80","validity_start_date":"2008-07-01T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
+        and magnesium alloy strip:<br/>-&nbsp;in rolls,<br/>-&nbsp;of a thickness
+        of 0,14&nbsp;mm or more but not more than 0,40&nbsp;mm,<br/>-&nbsp;a width
+        of 12,5&nbsp;mm or more but not more than 359&nbsp;mm,<br/>-&nbsp;a tensile
+        strength of 285&nbsp;N/mm<sup>2</sup>&nbsp;or more, and<br/>-&nbsp;an elongation
+        at break of 1% or more, and<br/>containing by weight:<br/>-&nbsp;93,3% or
+        more of aluminium,<br/>-&nbsp;2,2% or more but not more than 5% of magnesium,
+        and<br/>-&nbsp;not more than 1,8% of other elements","number_indents":4,"heading":{"goods_nomenclature_sid":47004,"goods_nomenclature_item_id":"7607000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
+        foil (whether or not printed or backed with paper, paperboard, plastics or
+        similar backing materials) of a thickness (excluding any backing) not exceeding
+        0,2&nbsp;mm","number_indents":0},"chapter":{"goods_nomenclature_sid":46925,"goods_nomenclature_item_id":"7600000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
+        and articles thereof"},"section":{"numeral":"XV","title":"Base metals and
+        articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"60940","_score":1.0,"_source":{"id":60940,"goods_nomenclature_item_id":"7616999030","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Plates
+        and sheets of variable thickness of widths of 1&nbsp;200&nbsp;mm or more,
+        for use in certain types of aircraft","number_indents":4,"heading":{"goods_nomenclature_sid":47069,"goods_nomenclature_item_id":"7616000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        articles of aluminium","number_indents":0},"chapter":{"goods_nomenclature_sid":46925,"goods_nomenclature_item_id":"7600000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
+        and articles thereof"},"section":{"numeral":"XV","title":"Base metals and
+        articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"74804","_score":1.0,"_source":{"id":74804,"goods_nomenclature_item_id":"7616999060","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+00:00","validity_end_date":null,"description":"Disc
+        (target) with deposition material, consisting of molybdenum silicide:<br/>-
+        containing 1&nbsp;mg/kg or less of sodium<br/>and<br/>- mounted on a metal
+        support","number_indents":5,"heading":{"goods_nomenclature_sid":47069,"goods_nomenclature_item_id":"7616000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        articles of aluminium","number_indents":0},"chapter":{"goods_nomenclature_sid":46925,"goods_nomenclature_item_id":"7600000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
+        and articles thereof"},"section":{"numeral":"XV","title":"Base metals and
+        articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97552","_score":1.0,"_source":{"id":97552,"goods_nomenclature_item_id":"7616999075","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"Parts
+        in the shape of a rectangular frame:<br/>-&nbsp;of painted aluminium,<br/>-&nbsp;with
+        a length of&nbsp;1&nbsp;011&nbsp;mm or more but not more than 1&nbsp;500&nbsp;mm,<br/>-&nbsp;with
+        a width of 622&nbsp;mm or more but not more than 900&nbsp;mm,<br/>-&nbsp;with
+        a thickness of 0,6&nbsp;mm (\u00b1 0,1&nbsp;mm),<br/>of a kind used in the
+        manufacture of TV sets","number_indents":5,"heading":{"goods_nomenclature_sid":47069,"goods_nomenclature_item_id":"7616000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        articles of aluminium","number_indents":0},"chapter":{"goods_nomenclature_sid":46925,"goods_nomenclature_item_id":"7600000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
+        and articles thereof"},"section":{"numeral":"XV","title":"Base metals and
+        articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"55267","_score":1.0,"_source":{"id":55267,"goods_nomenclature_item_id":"8104900010","producline_suffix":"80","validity_start_date":"1995-01-01T00:00:00+00:00","validity_end_date":null,"description":"Ground
+        and polished magnesium sheets, of dimensions not exceeding&nbsp;1&nbsp;500&times;2&nbsp;000&nbsp;mm,
+        coated on one side eith an epoxy resin insensitive to light","number_indents":2,"heading":{"goods_nomenclature_sid":47181,"goods_nomenclature_item_id":"8104000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Magnesium
+        and articles thereof, including waste and scrap","number_indents":0},"chapter":{"goods_nomenclature_sid":47149,"goods_nomenclature_item_id":"8100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Other
+        base metals; cermets; articles thereof"},"section":{"numeral":"XV","title":"Base
+        metals and articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97541","_score":1.0,"_source":{"id":97541,"goods_nomenclature_item_id":"8105900010","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"Bars
+        or wires made of cobalt alloy containing, by weight :<br/>-&nbsp;35% (\u00b1
+        2%) cobalt,<br/>-&nbsp;25% (\u00b1 1%)&nbsp;nickel,<br/>-&nbsp;19% (\u00b1
+        1%) chromium and<br/>-&nbsp;7% (\u00b1 2%) iron<br/>conforming to the material
+        specifications AMS 5842, of a kind used in the aerospace industry","number_indents":2,"heading":{"goods_nomenclature_sid":47197,"goods_nomenclature_item_id":"8105000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Cobalt
+        mattes and other intermediate products of cobalt metallurgy; cobalt and articles
+        thereof, including waste and scrap","number_indents":0},"chapter":{"goods_nomenclature_sid":47149,"goods_nomenclature_item_id":"8100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Other
+        base metals; cermets; articles thereof"},"section":{"numeral":"XV","title":"Base
+        metals and articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"81302","_score":1.0,"_source":{"id":81302,"goods_nomenclature_item_id":"8108300010","producline_suffix":"80","validity_start_date":"2005-01-01T00:00:00+00:00","validity_end_date":null,"description":"Waste
+        and scrap of titanium and titanium alloys, except those containing by weight
+        1% or more but not more than 2% of aluminium","number_indents":2,"heading":{"goods_nomenclature_sid":47208,"goods_nomenclature_item_id":"8108000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Titanium
+        and articles thereof, including waste and scrap","number_indents":0},"chapter":{"goods_nomenclature_sid":47149,"goods_nomenclature_item_id":"8100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Other
+        base metals; cermets; articles thereof"},"section":{"numeral":"XV","title":"Base
+        metals and articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90045","_score":1.0,"_source":{"id":90045,"goods_nomenclature_item_id":"8108903010","producline_suffix":"80","validity_start_date":"2008-07-01T00:00:00+00:00","validity_end_date":null,"description":"Titanium
+        alloy rods complying with standard EN 2002-1&nbsp;or EN 4267","number_indents":3,"heading":{"goods_nomenclature_sid":47208,"goods_nomenclature_item_id":"8108000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Titanium
+        and articles thereof, including waste and scrap","number_indents":0},"chapter":{"goods_nomenclature_sid":47149,"goods_nomenclature_item_id":"8100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Other
+        base metals; cermets; articles thereof"},"section":{"numeral":"XV","title":"Base
+        metals and articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90094","_score":1.0,"_source":{"id":90094,"goods_nomenclature_item_id":"8108903020","producline_suffix":"80","validity_start_date":"2008-07-01T00:00:00+00:00","validity_end_date":null,"description":"Bars,
+        rods and wire of alloy of titanium and aluminium, containing by weight 1%
+        or more but not more than 2% of aluminium, for use in the manufacture of silencers
+        and exhaust pipes of subheadings 8708&nbsp;92&nbsp;or 8714&nbsp;10&nbsp;00","number_indents":3,"heading":{"goods_nomenclature_sid":47208,"goods_nomenclature_item_id":"8108000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Titanium
+        and articles thereof, including waste and scrap","number_indents":0},"chapter":{"goods_nomenclature_sid":47149,"goods_nomenclature_item_id":"8100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Other
+        base metals; cermets; articles thereof"},"section":{"numeral":"XV","title":"Base
+        metals and articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"81304","_score":1.0,"_source":{"id":81304,"goods_nomenclature_item_id":"8108905010","producline_suffix":"80","validity_start_date":"2005-01-01T00:00:00+00:00","validity_end_date":null,"description":"Alloy
+        of titanium and aluminium, containing by weight 1% or more but not more than
+        2% of aluminium, in sheets or rolls, of a thickness of 0,49&nbsp;mm or more
+        but not exceeding 3,1&nbsp;mm, of a width of 1&nbsp;000&nbsp;mm or more but
+        not exceeding 1&nbsp;254&nbsp;mm, for the manufacture of goods of subheading
+        8714&nbsp;19&nbsp;00","number_indents":4,"heading":{"goods_nomenclature_sid":47208,"goods_nomenclature_item_id":"8108000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Titanium
+        and articles thereof, including waste and scrap","number_indents":0},"chapter":{"goods_nomenclature_sid":47149,"goods_nomenclature_item_id":"8100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Other
+        base metals; cermets; articles thereof"},"section":{"numeral":"XV","title":"Base
+        metals and articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96366","_score":1.0,"_source":{"id":96366,"goods_nomenclature_item_id":"8108905070","producline_suffix":"80","validity_start_date":"2012-07-01T00:00:00+00:00","validity_end_date":null,"description":"Strip
+        of an alloy of titanium, containing by weight <br/>\t\t\t\t\t\t<br/>-&nbsp;15%
+        (\u00b1 1%) of vanadium <br/>\t\t\t\t\t\t<br/>-&nbsp;3% (\u00b1 0,5%) of chromium
+        <br/>\t\t\t\t\t\t<br/>-&nbsp;3% (\u00b1 0,5%) of tin and <br/>\t\t\t\t\t\t<br/>-&nbsp;3%
+        (\u00b1 0,5%) of aluminium","number_indents":3,"heading":{"goods_nomenclature_sid":47208,"goods_nomenclature_item_id":"8108000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Titanium
+        and articles thereof, including waste and scrap","number_indents":0},"chapter":{"goods_nomenclature_sid":47149,"goods_nomenclature_item_id":"8100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Other
+        base metals; cermets; articles thereof"},"section":{"numeral":"XV","title":"Base
+        metals and articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96974","_score":1.0,"_source":{"id":96974,"goods_nomenclature_item_id":"8544200010","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"PET/PVC
+        insulated flexible cable with:<br/>\u2022\ta voltage of not more than 60 V,<br/>\u2022\ta
+        current of not more than 1 A,<br/>\u2022\ta heat resistance of not more than
+        105 \u00b0C,<br/>\u2022\tindividual wires of a thickness of not more than
+        0,1 mm (\u00b1 0,01 mm) and a width of not more than 0,8 mm (\u00b1 0,03 mm),<br/>\u2022\ta
+        distance between conductors of not more than 0,5 mm and<br/>\u2022\ta pitch
+        (distance from centreline to centreline of conductors) of not more than 1,25
+        mm","number_indents":2,"heading":{"goods_nomenclature_sid":52840,"goods_nomenclature_item_id":"8544000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insulated
+        (including enamelled or anodised) wire, cable (including coaxial cable) and
+        other insulated electric conductors, whether or not fitted with connectors;
+        optical fibre cables, made up of individually sheathed fibres, whether or
+        not assembled with electric conductors or fitted with connectors","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        machinery and equipment and parts thereof; sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
+        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"87974","_score":1.0,"_source":{"id":87974,"goods_nomenclature_item_id":"8544420000","producline_suffix":"10","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        electric conductors, for a voltage not exceeding 1&nbsp;000&nbsp;V","number_indents":1,"heading":{"goods_nomenclature_sid":52840,"goods_nomenclature_item_id":"8544000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insulated
+        (including enamelled or anodised) wire, cable (including coaxial cable) and
+        other insulated electric conductors, whether or not fitted with connectors;
+        optical fibre cables, made up of individually sheathed fibres, whether or
+        not assembled with electric conductors or fitted with connectors","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        machinery and equipment and parts thereof; sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
+        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91190","_score":1.0,"_source":{"id":91190,"goods_nomenclature_item_id":"8544429010","producline_suffix":"80","validity_start_date":"2009-07-01T00:00:00+00:00","validity_end_date":null,"description":"Data
+        transmission cable capable of a bit rate transmission of 600&nbsp;Mbit/s or
+        more, with:<br/>-&nbsp;a voltage of 1,25&nbsp;V&nbsp;(\u00b1&nbsp;0,25&nbsp;V)<br/>-&nbsp;connectors
+        fitted at one or both ends, at least one of which contains pins with a pitch
+        of&nbsp;1&nbsp;mm,<br/>-&nbsp;outer screening shielding,<br/>used solely for
+        communication between LCD, PDP or OLED panel and video processing electronic
+        circuits","number_indents":4,"heading":{"goods_nomenclature_sid":52840,"goods_nomenclature_item_id":"8544000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insulated
+        (including enamelled or anodised) wire, cable (including coaxial cable) and
+        other insulated electric conductors, whether or not fitted with connectors;
+        optical fibre cables, made up of individually sheathed fibres, whether or
+        not assembled with electric conductors or fitted with connectors","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        machinery and equipment and parts thereof; sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
+        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96975","_score":1.0,"_source":{"id":96975,"goods_nomenclature_item_id":"8544429020","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"PET/PVC
+        insulated flexible cable with:<br/>\u2022\ta voltage of not more than 60 V,<br/>\u2022\ta
+        current of not more than 1 A,<br/>\u2022\ta heat resistance of not more than
+        105 \u00b0C,<br/>\u2022\tindividual wires of a thickness of not more than
+        0,1 mm (\u00b1 0,01 mm) and a width of not more than 0,8 mm (\u00b1 0,03 mm),<br/>\u2022\ta
+        distance between conductors of not more than 0,5 mm and<br/>\u2022\ta pitch
+        (distance from centreline to centreline of conductors) of not more than 1,25
+        mm","number_indents":4,"heading":{"goods_nomenclature_sid":52840,"goods_nomenclature_item_id":"8544000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insulated
+        (including enamelled or anodised) wire, cable (including coaxial cable) and
+        other insulated electric conductors, whether or not fitted with connectors;
+        optical fibre cables, made up of individually sheathed fibres, whether or
+        not assembled with electric conductors or fitted with connectors","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        machinery and equipment and parts thereof; sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
+        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90675","_score":1.0,"_source":{"id":90675,"goods_nomenclature_item_id":"8544499320","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"PET/PVC
+        insulated flexible cable with:<br/>-&nbsp;a voltage of not more than 60&nbsp;V,<br/>-&nbsp;a
+        current of not more than 1&nbsp;A<br/>-&nbsp;a heat resistance of not more
+        than 105\u00b0C,<br/>-&nbsp;individual wires of a thickness of 0,05&nbsp;mm
+        (\u00b1&nbsp;0,01&nbsp;mm) and a width of not more than 0,65&nbsp;mm (\u00b1&nbsp;0,03&nbsp;mm)<br/>-&nbsp;distance
+        between conductors of not more than 0,5&nbsp;mm and<br/>-&nbsp;pitch (distance
+        from centreline to centreline of conductors) of not more than 1,08&nbsp;mm","number_indents":6,"heading":{"goods_nomenclature_sid":52840,"goods_nomenclature_item_id":"8544000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insulated
+        (including enamelled or anodised) wire, cable (including coaxial cable) and
+        other insulated electric conductors, whether or not fitted with connectors;
+        optical fibre cables, made up of individually sheathed fibres, whether or
+        not assembled with electric conductors or fitted with connectors","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        machinery and equipment and parts thereof; sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
+        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"87982","_score":1.0,"_source":{"id":87982,"goods_nomenclature_item_id":"8544499500","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"For
+        a voltage exceeding 80&nbsp;V but less than 1&nbsp;000&nbsp;V","number_indents":5,"heading":{"goods_nomenclature_sid":52840,"goods_nomenclature_item_id":"8544000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insulated
+        (including enamelled or anodised) wire, cable (including coaxial cable) and
+        other insulated electric conductors, whether or not fitted with connectors;
+        optical fibre cables, made up of individually sheathed fibres, whether or
+        not assembled with electric conductors or fitted with connectors","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        machinery and equipment and parts thereof; sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
+        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96977","_score":1.0,"_source":{"id":96977,"goods_nomenclature_item_id":"8544499510","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"PET/PVC
+        insulated flexible cable with:<br/>\u2022\ta voltage of not more than 60 V,<br/>\u2022\ta
+        current of not more than 1 A,<br/>\u2022\ta heat resistance of not more than
+        105 \u00b0C,<br/>\u2022\tindividual wires of a thickness of not more than
+        0,1 mm (\u00b1 0,01 mm) and a width of not more than 0,8 mm (\u00b1 0,03 mm),<br/>\u2022\ta
+        distance between conductors of not more than 0,5 mm and<br/>\u2022\ta pitch
+        (distance from centreline to centreline of conductors) of not more than 1,25
+        mm","number_indents":6,"heading":{"goods_nomenclature_sid":52840,"goods_nomenclature_item_id":"8544000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insulated
+        (including enamelled or anodised) wire, cable (including coaxial cable) and
+        other insulated electric conductors, whether or not fitted with connectors;
+        optical fibre cables, made up of individually sheathed fibres, whether or
+        not assembled with electric conductors or fitted with connectors","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        machinery and equipment and parts thereof; sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
+        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"87983","_score":1.0,"_source":{"id":87983,"goods_nomenclature_item_id":"8544499900","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"For
+        a voltage of 1&nbsp;000&nbsp;V","number_indents":5,"heading":{"goods_nomenclature_sid":52840,"goods_nomenclature_item_id":"8544000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insulated
+        (including enamelled or anodised) wire, cable (including coaxial cable) and
+        other insulated electric conductors, whether or not fitted with connectors;
+        optical fibre cables, made up of individually sheathed fibres, whether or
+        not assembled with electric conductors or fitted with connectors","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        machinery and equipment and parts thereof; sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
+        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"52884","_score":1.0,"_source":{"id":52884,"goods_nomenclature_item_id":"8544600000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
+        electric conductors, for a voltage exceeding 1&nbsp;000&nbsp;V","number_indents":1,"heading":{"goods_nomenclature_sid":52840,"goods_nomenclature_item_id":"8544000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insulated
+        (including enamelled or anodised) wire, cable (including coaxial cable) and
+        other insulated electric conductors, whether or not fitted with connectors;
+        optical fibre cables, made up of individually sheathed fibres, whether or
+        not assembled with electric conductors or fitted with connectors","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        machinery and equipment and parts thereof; sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
+        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"67059","_score":1.0,"_source":{"id":67059,"goods_nomenclature_item_id":"8536501991","producline_suffix":"80","validity_start_date":"1997-07-01T00:00:00+00:00","validity_end_date":null,"description":"Hall
+        effect switch, comprising 1 magnet, 1 Hall effect sensor and 2 capacitors,
+        contained in a housing with 3 connections and bearing:<br/>- an identification
+        marking consisting of or including (one of) the following combination(s):<br/>2AV28E     2AV31E     2AV56      <br/>or<br/>-
+        other identification markings relating to devices complying with the abovementioned
+        description","number_indents":5,"heading":{"goods_nomenclature_sid":50711,"goods_nomenclature_item_id":"8536000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        apparatus for switching or protecting electrical circuits, or for making connections
+        to or in electrical circuits (for example, switches, relays, fuses, surge
+        suppressors, plugs, sockets, lamp-holders, junction boxes), for a voltage
+        not exceeding&nbsp;1&nbsp;000&nbsp;volts","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        machinery and equipment and parts thereof; sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
+        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96969","_score":1.0,"_source":{"id":96969,"goods_nomenclature_item_id":"8536699088","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"Secure
+        Digital (SD), CompactFlash, \"Smart Card\" and 64- pin PC-card female connectors,
+        of a kind used for soldering on printed circuit boards, for connecting electrical
+        apparatus and circuits and switching or protecting electrical circuits with
+        a voltage of not more than 1 000 V","number_indents":5,"heading":{"goods_nomenclature_sid":50711,"goods_nomenclature_item_id":"8536000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        apparatus for switching or protecting electrical circuits, or for making connections
+        to or in electrical circuits (for example, switches, relays, fuses, surge
+        suppressors, plugs, sockets, lamp-holders, junction boxes), for a voltage
+        not exceeding&nbsp;1&nbsp;000&nbsp;volts","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        machinery and equipment and parts thereof; sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
+        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"50825","_score":1.0,"_source":{"id":50825,"goods_nomenclature_item_id":"8537100000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"For
+        a voltage not exceeding 1&nbsp;000&nbsp;V","number_indents":1,"heading":{"goods_nomenclature_sid":50824,"goods_nomenclature_item_id":"8537000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Boards,
+        panels (including numerical control panels), consoles, desks, cabinets and
+        other bases, equipped with two or more apparatus of heading No  8535&nbsp;or  8536,
+        for electric control or the distribution of electricity, including those incorporating
+        instruments or apparatus of Chapter 90, other than switching apparatus of
+        heading No  8517","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        machinery and equipment and parts thereof; sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
+        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"50842","_score":1.0,"_source":{"id":50842,"goods_nomenclature_item_id":"8537200000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"For
+        a voltage exceeding 1&nbsp;000&nbsp;V","number_indents":1,"heading":{"goods_nomenclature_sid":50824,"goods_nomenclature_item_id":"8537000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Boards,
+        panels (including numerical control panels), consoles, desks, cabinets and
+        other bases, equipped with two or more apparatus of heading No  8535&nbsp;or  8536,
+        for electric control or the distribution of electricity, including those incorporating
+        instruments or apparatus of Chapter 90, other than switching apparatus of
+        heading No  8517","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        machinery and equipment and parts thereof; sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
+        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"50847","_score":1.0,"_source":{"id":50847,"goods_nomenclature_item_id":"8537209100","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Exceeding&nbsp;1&nbsp;000&nbsp;volts
+        but not exceeding&nbsp;72,5&nbsp;kV","number_indents":3,"heading":{"goods_nomenclature_sid":50824,"goods_nomenclature_item_id":"8537000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Boards,
+        panels (including numerical control panels), consoles, desks, cabinets and
+        other bases, equipped with two or more apparatus of heading No  8535&nbsp;or  8536,
+        for electric control or the distribution of electricity, including those incorporating
+        instruments or apparatus of Chapter 90, other than switching apparatus of
+        heading No  8517","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        machinery and equipment and parts thereof; sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
+        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"98050","_score":1.0,"_source":{"id":98050,"goods_nomenclature_item_id":"8538909995","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"Copper
+        base plate, of a kind used as a heatsink in the manufacture of IGBT modules
+        of heading 8535&nbsp;or 8536&nbsp;with a voltage of 650&nbsp;V or more but
+        not more than 1&nbsp;200&nbsp;V","number_indents":5,"heading":{"goods_nomenclature_sid":50853,"goods_nomenclature_item_id":"8538000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Parts
+        suitable for use solely or principally with the apparatus of heading Nos  8535,  8536&nbsp;or  8537","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        machinery and equipment and parts thereof; sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
+        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"51113","_score":1.0,"_source":{"id":51113,"goods_nomenclature_item_id":"8541210000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
+        a dissipation rate of less than 1&nbsp;W","number_indents":2,"heading":{"goods_nomenclature_sid":51101,"goods_nomenclature_item_id":"8541000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Diodes,
+        transistors and similar semiconductor devices; photosensitive semiconductor
+        devices, including photovoltaic cells whether or not assembled in modules
+        or made up into panels; light-emitting diodes; mounted piezoelectric crystals","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        machinery and equipment and parts thereof; sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
+        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97550","_score":1.0,"_source":{"id":97550,"goods_nomenclature_item_id":"8525801945","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"Camera
+        module with a resolution of 1&nbsp;280&nbsp;*&nbsp;720&nbsp;P&nbsp;HD, with
+        two microphones, for use in the manufacture of products of heading 8528","number_indents":4,"heading":{"goods_nomenclature_sid":50280,"goods_nomenclature_item_id":"8525000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Transmission
+        apparatus for radio-telephony, radio-telegraphy, radio-broadcasting or television,
+        whether or not incorporating reception apparatus or sound recording or reproducing
+        apparatus; television cameras","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        machinery and equipment and parts thereof; sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
+        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"87634","_score":1.0,"_source":{"id":87634,"goods_nomenclature_item_id":"8529108020","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"Ceramic
+        filter package comprising 2 ceramic filters and 1 ceramic resonator for a
+        frequency of 10,7 MHz (+/-30 kHz), contained in a housing","number_indents":3,"heading":{"goods_nomenclature_sid":50452,"goods_nomenclature_item_id":"8529000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Parts
+        suitable for use solely or principally with the apparatus of headings&nbsp;8525&nbsp;to
+        8528","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        machinery and equipment and parts thereof; sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
+        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"87642","_score":1.0,"_source":{"id":87642,"goods_nomenclature_item_id":"8529108060","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"Filters,
+        excluding surface acoustic wave filters, for a center frequency of 485 MHz
+        or more but not exceeding 1 990 MHz with an insertion loss not exceeding 3,5
+        dB, contained in a housing","number_indents":3,"heading":{"goods_nomenclature_sid":50452,"goods_nomenclature_item_id":"8529000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Parts
+        suitable for use solely or principally with the apparatus of headings&nbsp;8525&nbsp;to
+        8528","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
+        machinery and equipment and parts thereof; sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
+        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
+        television image and sound recorders and reproducers, and parts and accessories
+        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97551","_score":1.0,"_source":{"id":97551,"goods_nomenclature_item_id":"8529909270","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"Rectangular
+        fastening and covering frame:<br/>-&nbsp;of an aluminium alloy containing
+        silicon and magnesium,<br/>-&nbsp;with a length of&nbsp;900&nbsp;mm or more
+        but not more than 1&nbsp;500&nbsp;mm,<br/>-&nbsp;with a width of 600&nbsp;mm
+        or more but not more than 950&nbsp;mm,<br/>of a kind used for the production&nbsp;of
+        TV sets","number_indents":5,"heading":{"goods_nomenclature_sid":50452,"goods_nomenclature_item_id":"8529000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Parts
+        suitable for use solely or principally with the apparatus of headings&nbsp;8525&nbsp;to
+        8528","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
         machinery and equipment and parts thereof; sound recorders and reproducers,
         television image and sound recorders and reproducers, and parts and accessories
         of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
@@ -2510,890 +3392,6 @@ http_interactions:
         of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
         appliances; electrical equipment; parts thereof, sound recorders and reproducers,
         television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"48250","_score":1.0,"_source":{"id":48250,"goods_nomenclature_item_id":"8427101000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
-        a lifting height of 1&nbsp;m or more","number_indents":2,"heading":{"goods_nomenclature_sid":48248,"goods_nomenclature_item_id":"8427000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fork-lift
-        trucks; other works trucks fitted with lifting or handling equipment","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
-        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
-        and mechanical appliances; electrical equipment; parts thereof, sound recorders
-        and reproducers, television image and sound recorders and reproducers, and
-        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"48253","_score":1.0,"_source":{"id":48253,"goods_nomenclature_item_id":"8427201100","producline_suffix":"10","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
-        a lifting height of 1&nbsp;m or more","number_indents":2,"heading":{"goods_nomenclature_sid":48248,"goods_nomenclature_item_id":"8427000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Fork-lift
-        trucks; other works trucks fitted with lifting or handling equipment","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
-        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
-        and mechanical appliances; electrical equipment; parts thereof, sound recorders
-        and reproducers, television image and sound recorders and reproducers, and
-        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93712","_score":1.0,"_source":{"id":93712,"goods_nomenclature_item_id":"3808939040","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"Mixed
-        white powder containing by weight: <br/>-&nbsp;3% or more but not more than
-        3,6% of 1-methylcyclopropene with a purity more than 96% and <br/>-&nbsp;containing
-        less than 0,05% of each impurity of 1-chloro-2-methylpropene and 3-chloro-2-methylpropene
-        <br/>for use in the manufacture of a growth regulator of post-harvest fruits,
-        vegetables and ornamentals with a specific generator","number_indents":4,"heading":{"goods_nomenclature_sid":38368,"goods_nomenclature_item_id":"3808000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insecticides,
-        rodenticides, fungicides, herbicides, anti-sprouting products and plant-growth
-        regulators, disinfectants and similar products, put up in forms or packings
-        for retail sale or as preparations or articles (for example, sulphur-treated
-        bands, wicks and candles, and fly-papers)","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93713","_score":1.0,"_source":{"id":93713,"goods_nomenclature_item_id":"3808939050","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"Preparation
-        in the form of powder, containing by weight: <br/>-&nbsp;55% or more of Gibberellin
-        A4, <br/>-&nbsp;1% or more but not more than 35% of Gibberellin A7, <br/>-&nbsp;90%
-        or more of Gibberellin A4&nbsp;and Gibberellin A7&nbsp;combined <br/>-&nbsp;not
-        more than 10% of a combination of water and other naturally occurring Gibberellins
-        <br/>of a kind used in plant growth regulators","number_indents":4,"heading":{"goods_nomenclature_sid":38368,"goods_nomenclature_item_id":"3808000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insecticides,
-        rodenticides, fungicides, herbicides, anti-sprouting products and plant-growth
-        regulators, disinfectants and similar products, put up in forms or packings
-        for retail sale or as preparations or articles (for example, sulphur-treated
-        bands, wicks and candles, and fly-papers)","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96890","_score":1.0,"_source":{"id":96890,"goods_nomenclature_item_id":"3811290040","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"Additives
-        for lubricating oils, consisting of reaction products of 2-methyl-prop-1-ene&nbsp;
-        with sulphur monochloride and sodium sulphide (CAS RN 68511-50-2), with a
-        chlorine content by weight of 0,05% or more but not more than&nbsp; 0,5%,
-        used as a concentrated additive for the manufacture of engine oils through
-        a blending process","number_indents":3,"heading":{"goods_nomenclature_sid":38428,"goods_nomenclature_item_id":"3811000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Anti-knock
-        preparations, oxidation inhibitors, gum inhibitors, viscosity improvers, anti-corrosive
-        preparations and other prepared additives, for mineral oils (including gasoline)
-        or for other liquids used for the same purposes as mineral oils","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"65223","_score":1.0,"_source":{"id":65223,"goods_nomenclature_item_id":"3812201000","producline_suffix":"80","validity_start_date":"1997-01-01T00:00:00+00:00","validity_end_date":null,"description":"Reaction
-        mixture containing benzyl 3-isobutyryloxy-1-isopropyl-2,2-dimethylpropyl phthalate
-        and benzyl 3-isobutyryloxy-2,2,4-trimethylpentyl phthalate","number_indents":2,"heading":{"goods_nomenclature_sid":38440,"goods_nomenclature_item_id":"3812000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
-        rubber accelerators; compound plasticisers for rubber or plastics, not elsewhere
-        specified or included; anti-oxidising preparations and other compound stabilisers
-        for rubber or plastics","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"58617","_score":1.0,"_source":{"id":58617,"goods_nomenclature_item_id":"3812308020","producline_suffix":"80","validity_start_date":"1995-07-01T00:00:00+00:00","validity_end_date":null,"description":"Mixture
-        containing predominantly bis(2,2,6,6-tetramethyl-1-octyloxy-4-piperidyl) sebacate","number_indents":3,"heading":{"goods_nomenclature_sid":38440,"goods_nomenclature_item_id":"3812000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
-        rubber accelerators; compound plasticisers for rubber or plastics, not elsewhere
-        specified or included; anti-oxidising preparations and other compound stabilisers
-        for rubber or plastics","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"98109","_score":1.0,"_source":{"id":98109,"goods_nomenclature_item_id":"3812308025","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"UV&nbsp;photo
-        stabiliser containing:<br/>-&nbsp;\u03b1-[3-[3-(2H-Benzotriazol-2-yl)-5-(1,1-dimethylethyl)-4-hydroxyphenyl]-1-oxopropyl]-\u03c9-hydroxypoly(oxy-1,2-ethanediyl)
-        (CAS RN 104810-48-2); &nbsp;<br/>-&nbsp;\u03b1-[3-[3-(2H-Benzotriazol-2-yl)-5-(1,1-dimethylethyl)-4-hydroxyphenyl]-1-oxopropyl]-\u03c9-[3-[3-(2H-benzotriazol-2-yl)-5-(1,1-dimethylethyl)-4-hydroxyphenyl]-1-oxopropoxy]poly
-        (oxy-1,2-ethanediyl) (CAS RN 104810-47-1);&nbsp;<br/>-&nbsp;polyethylene glycol
-        of a weight average molecular weight (Mw) of 300&nbsp;(CAS RN 25322-68-3)<br/>-&nbsp;bis
-        (1,2,2,6,6-pentamethyl-4-piperidyl)sebacate (CAS RN 41556-26-7), and<br/>-&nbsp;methyl-1,2,2,6,6-pentamethyl-4-
-        piperidyl sebacate (CAS RN 82919-37-7)","number_indents":3,"heading":{"goods_nomenclature_sid":38440,"goods_nomenclature_item_id":"3812000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
-        rubber accelerators; compound plasticisers for rubber or plastics, not elsewhere
-        specified or included; anti-oxidising preparations and other compound stabilisers
-        for rubber or plastics","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96279","_score":1.0,"_source":{"id":96279,"goods_nomenclature_item_id":"3812308065","producline_suffix":"80","validity_start_date":"2012-07-01T00:00:00+00:00","validity_end_date":null,"description":"Stabiliser
-        for plastic material containing: <br/>\t\t\t\t\t\t<br/>-&nbsp;2-ethylhexyl
-        10-ethyl-4,4-dimethyl-7-oxo-8-oxa-3,5-dithia-4-stannatetradecanoate (CAS&nbsp;RN&nbsp;57583-35-4),
-        <br/>\t\t\t\t\t\t<br/>-&nbsp;2-ethylhexyl 10-ethyl-4-[[2-[(2-ethylhexyl)oxy]-2-oxoethyl]thio]-4-methyl-7-oxo-8-oxa-3,5-dithia-4-stannatetradecanoate
-        (CAS&nbsp;RN&nbsp;57583-34-3), and <br/>\t\t\t\t\t\t<br/>-&nbsp;2-ethylhexyl
-        mercaptoacetate (CAS RN 7659-86-1)","number_indents":3,"heading":{"goods_nomenclature_sid":38440,"goods_nomenclature_item_id":"3812000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
-        rubber accelerators; compound plasticisers for rubber or plastics, not elsewhere
-        specified or included; anti-oxidising preparations and other compound stabilisers
-        for rubber or plastics","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96281","_score":1.0,"_source":{"id":96281,"goods_nomenclature_item_id":"3812308070","producline_suffix":"80","validity_start_date":"2012-07-01T00:00:00+00:00","validity_end_date":null,"description":"Light
-        stabiliser containing: <br/>\t\t\t\t\t\t<br/>-&nbsp;branched and linear alkyl
-        esters of 3-(2H-benzotriazolyl)-5-(1,1-dimethylethyl)-4-hydroxybenzenepropanoic
-        acid (CAS&nbsp;RN&nbsp;127519-17-9), and <br/>\t\t\t\t\t\t<br/>-&nbsp;1-methoxy-2-propyl
-        acetate (CAS RN 108-65-6)","number_indents":3,"heading":{"goods_nomenclature_sid":38440,"goods_nomenclature_item_id":"3812000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
-        rubber accelerators; compound plasticisers for rubber or plastics, not elsewhere
-        specified or included; anti-oxidising preparations and other compound stabilisers
-        for rubber or plastics","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"80582","_score":1.0,"_source":{"id":80582,"goods_nomenclature_item_id":"3814009020","producline_suffix":"80","validity_start_date":"2004-07-01T00:00:00+00:00","validity_end_date":null,"description":"Mixture
-        containing by weight:<br/>- 69% or more but not more than 71% of 1-methoxypropan-2-ol,<br/>-
-        29% or more but not more than 31% of 2-methoxy-1-methylethyl acetate","number_indents":2,"heading":{"goods_nomenclature_sid":38461,"goods_nomenclature_item_id":"3814000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Organic
-        composite solvents and thinners, not elsewhere specified or included; prepared
-        paint or varnish removers","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96894","_score":1.0,"_source":{"id":96894,"goods_nomenclature_item_id":"3815909018","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"Oxidation
-        catalyst with an active ingredient of di[manganese (1+)], 1,2-bis(octahydro-4,7-dimethyl-1H-1,4,7-triazonine-1-yl-kN<sup>1</sup>,
-        kN<sup>4</sup>, kN<sup>7</sup>)ethane-di-\u03bc-oxo-\u03bc-(ethanoato-kO,
-        kO'')-, di[chloride(1-)], used to accelerate chemical oxidation or bleaching
-        (CAS RN 1217890-37-3)","number_indents":3,"heading":{"goods_nomenclature_sid":38464,"goods_nomenclature_item_id":"3815000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Reaction
-        initiators, reaction accelerators and catalytic preparations, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"70737","_score":1.0,"_source":{"id":70737,"goods_nomenclature_item_id":"3815909081","producline_suffix":"80","validity_start_date":"1999-07-01T00:00:00+00:00","validity_end_date":null,"description":"Catalyst,
-        containing by weight 38% or more but not more than 48% of (2-hydroxy-1-methylethyl)trimethylammonium
-        2-ethylhexanoate","number_indents":3,"heading":{"goods_nomenclature_sid":38464,"goods_nomenclature_item_id":"3815000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Reaction
-        initiators, reaction accelerators and catalytic preparations, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"79285","_score":1.0,"_source":{"id":79285,"goods_nomenclature_item_id":"3815909086","producline_suffix":"80","validity_start_date":"2004-01-01T00:00:00+00:00","validity_end_date":null,"description":"Catalyst,
-        in the form of rodlets, consisting of an aluminosilicate (zeolite), containing
-        by weight 2% or more but not more than 3% of rare-earth metals oxides and
-        less than 1% of disodium oxide","number_indents":3,"heading":{"goods_nomenclature_sid":38464,"goods_nomenclature_item_id":"3815000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Reaction
-        initiators, reaction accelerators and catalytic preparations, not elsewhere
-        specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"65263","_score":1.0,"_source":{"id":65263,"goods_nomenclature_item_id":"3824908500","producline_suffix":"80","validity_start_date":"1997-01-01T00:00:00+00:00","validity_end_date":null,"description":"3-(1-Ethyl-1-methylpropyl)isoxazol-5-ylamine,
-        in the form of a solution in toluene","number_indents":4,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
-        binders for foundry moulds or cores; chemical products and preparations of
-        the chemical or allied industries (including those consisting of mixtures
-        of natural products), not elsewhere specified or included; residual products
-        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91143","_score":1.0,"_source":{"id":91143,"goods_nomenclature_item_id":"3824909716","producline_suffix":"80","validity_start_date":"2009-07-01T00:00:00+00:00","validity_end_date":null,"description":"Mixture
-        of bis{4-(3-(3-phenoxycarbonylamino)tolyl)ureido}phenylsulphone, diphenyltoluene-2,4-dicarbamate
-        and 1-[4-(4-aminobenzenesulphonyl)-phenyl]-3-(3-phenoxycarbonylamino-tolyl)-urea","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
-        binders for foundry moulds or cores; chemical products and preparations of
-        the chemical or allied industries (including those consisting of mixtures
-        of natural products), not elsewhere specified or included; residual products
-        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97512","_score":1.0,"_source":{"id":97512,"goods_nomenclature_item_id":"3824909718","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"Poly(tetramethylene
-        glycol) bis[(9-oxo-9H-thioxanthen-1-yloxy)acetate]&nbsp;with an average polymer
-        chain length of less than 5&nbsp;monomer units (CAS RN 515136-48-8)","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
-        binders for foundry moulds or cores; chemical products and preparations of
-        the chemical or allied industries (including those consisting of mixtures
-        of natural products), not elsewhere specified or included; residual products
-        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"92695","_score":1.0,"_source":{"id":92695,"goods_nomenclature_item_id":"3824909721","producline_suffix":"80","validity_start_date":"2010-07-01T00:00:00+00:00","validity_end_date":null,"description":"Mixture
-        of 2-propenoic acid, (1-methylethylidene)bis(4,1-phenyleneoxy-2,1-ethanediyloxy-2,1-ethanediyl)ester
-        with 2-propenoic acid, (2,4,6-trioxo-1,3,5-triazine-1,3,5(2H,4H,6H)-triyl)tri-2,1-ethanediyl
-        ester and 1-hydroxy-cyclohexyl-phenyl ketone in the solution of methyl ethyl
-        ketone and toluene","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
-        binders for foundry moulds or cores; chemical products and preparations of
-        the chemical or allied industries (including those consisting of mixtures
-        of natural products), not elsewhere specified or included; residual products
-        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96348","_score":1.0,"_source":{"id":96348,"goods_nomenclature_item_id":"3824909726","producline_suffix":"80","validity_start_date":"2012-07-01T00:00:00+00:00","validity_end_date":null,"description":"Aqueous
-        dispersion, containing&nbsp; by weight: <br/>\t\t\t\t\t\t<br/>-&nbsp;76%&nbsp;
-        (\u00b1&nbsp;0,5%)&nbsp;of silicon carbide (CAS RN&nbsp;409-21-2) <br/>\t\t\t\t\t\t<br/>-&nbsp;4,6%&nbsp;(\u00b1&nbsp;0,05%)
-        of aluminium oxide&nbsp;(CAS RN 1344-28-1)&nbsp;and <br/>\t\t\t\t\t\t<br/>-&nbsp;2,4%&nbsp;(\u00b1&nbsp;0,05%)&nbsp;of&nbsp;yttrium
-        oxide&nbsp;(CAS RN&nbsp;1314-36-9)","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
-        binders for foundry moulds or cores; chemical products and preparations of
-        the chemical or allied industries (including those consisting of mixtures
-        of natural products), not elsewhere specified or included; residual products
-        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96895","_score":1.0,"_source":{"id":96895,"goods_nomenclature_item_id":"3824909735","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"Mixture
-        of:<br/>-&nbsp;3,3-bis(2-methyl-1-octyl-1H-indol-3-yl)phthalide (CAS RN 50292-95-0)
-        and<br/>-&nbsp;ethyl-6''-(diethylamino)-3-oxo-spiro-[isobenzofuran-1(3H),9''-[9H]xanthene]-2''-carboxylate
-        (CAS RN 154306-60-2)","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
-        binders for foundry moulds or cores; chemical products and preparations of
-        the chemical or allied industries (including those consisting of mixtures
-        of natural products), not elsewhere specified or included; residual products
-        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97513","_score":1.0,"_source":{"id":97513,"goods_nomenclature_item_id":"3824909747","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"Platinum
-        oxide (CAS RN 12035-82-4) fixed on a porous support of aluminium oxide (CAS
-        RN 1344-28-1), containing by weight:<br/>-&nbsp;0,1% or more but not more
-        than 1% of platinum, and<br/>-&nbsp;0,5% or more but not more than 5% of ethylaluminium
-        dichloride (CAS RN 563-43-9)","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
-        binders for foundry moulds or cores; chemical products and preparations of
-        the chemical or allied industries (including those consisting of mixtures
-        of natural products), not elsewhere specified or included; residual products
-        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"89603","_score":1.0,"_source":{"id":89603,"goods_nomenclature_item_id":"3824909748","producline_suffix":"80","validity_start_date":"2008-01-01T00:00:00+00:00","validity_end_date":null,"description":"Rare-earth
-        concentrate containing by weight 60% or more but not more than 95% of rare-earth
-        oxides and not more than 1% each of zirconium oxide, aluminium oxide or iron
-        oxide, and having a loss on ignition of 5% or more by weight","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
-        binders for foundry moulds or cores; chemical products and preparations of
-        the chemical or allied industries (including those consisting of mixtures
-        of natural products), not elsewhere specified or included; residual products
-        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93717","_score":1.0,"_source":{"id":93717,"goods_nomenclature_item_id":"3824909758","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"N2-[1-(S)-Ethoxycarbonyl-3-phenylpropyl]-N6-trifluoroacetyl-L-lysyl-N2-carboxy
-        anhydride in a solution of dichloromethane at 37%","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
-        binders for foundry moulds or cores; chemical products and preparations of
-        the chemical or allied industries (including those consisting of mixtures
-        of natural products), not elsewhere specified or included; residual products
-        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93821","_score":1.0,"_source":{"id":93821,"goods_nomenclature_item_id":"3824909765","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+00:00","validity_end_date":null,"description":"Preparation
-        containing by weight: <br/>-&nbsp;89% or more but not more than 98,9% of 1,2,3-trideoxy-4,6:5,7-bis-O-[(4-propylphenyl)methylene]-nonitol
-        <br/>-&nbsp;0,1% or more but not more than 1% of colorants <br/>-&nbsp;1%
-        or more but not more than 10% of fluoropolymers","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
-        binders for foundry moulds or cores; chemical products and preparations of
-        the chemical or allied industries (including those consisting of mixtures
-        of natural products), not elsewhere specified or included; residual products
-        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90749","_score":1.0,"_source":{"id":90749,"goods_nomenclature_item_id":"3824909779","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"Mixture
-        of 80% (\u00b1&nbsp;10%) of 1-[2-(2-aminobutoxy)ethoxy]but-2-ylamine and 20%(\u00b1&nbsp;10%)
-        of 1-({[2-(2-aminobutoxy)ethoxy]methyl} propoxy)but-2-ylamine","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
-        binders for foundry moulds or cores; chemical products and preparations of
-        the chemical or allied industries (including those consisting of mixtures
-        of natural products), not elsewhere specified or included; residual products
-        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"89640","_score":1.0,"_source":{"id":89640,"goods_nomenclature_item_id":"3824909784","producline_suffix":"80","validity_start_date":"2008-01-01T00:00:00+00:00","validity_end_date":null,"description":"Reaction
-        product, containing by weight:<br/>- 1% or more but not more than 40% of molybdenum
-        oxide,<br/>- 10% or more but not more than 50% of nickel oxide,<br/>- 30%
-        or more but not more than 70% of tungsten oxide","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
-        binders for foundry moulds or cores; chemical products and preparations of
-        the chemical or allied industries (including those consisting of mixtures
-        of natural products), not elsewhere specified or included; residual products
-        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"88928","_score":1.0,"_source":{"id":88928,"goods_nomenclature_item_id":"3824909798","producline_suffix":"80","validity_start_date":"2008-01-01T00:00:00+00:00","validity_end_date":null,"description":"Mixture
-        of tertiary amines containing by weight:<br/>- 2.0-4.0% of N,N-dimethyl-1-octanamine<br/>-
-        94% minimum of N,N-dimethyl-1-decanamine<br/>- 2% maximum of N,N-dimethyl-1-dodecanamine","number_indents":5,"heading":{"goods_nomenclature_sid":59671,"goods_nomenclature_item_id":"3824000000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Prepared
-        binders for foundry moulds or cores; chemical products and preparations of
-        the chemical or allied industries (including those consisting of mixtures
-        of natural products), not elsewhere specified or included; residual products
-        of the chemical or allied industries, not elsewhere specified or included","number_indents":0},"chapter":{"goods_nomenclature_sid":38322,"goods_nomenclature_item_id":"3800000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        chemical products"},"section":{"numeral":"VI","title":"Products of the chemical
-        or allied industries","position":6}}},{"_index":"tariff-commodities","_type":"commodity","_id":"67059","_score":1.0,"_source":{"id":67059,"goods_nomenclature_item_id":"8536501991","producline_suffix":"80","validity_start_date":"1997-07-01T00:00:00+00:00","validity_end_date":null,"description":"Hall
-        effect switch, comprising 1 magnet, 1 Hall effect sensor and 2 capacitors,
-        contained in a housing with 3 connections and bearing:<br/>- an identification
-        marking consisting of or including (one of) the following combination(s):<br/>2AV28E     2AV31E     2AV56      <br/>or<br/>-
-        other identification markings relating to devices complying with the abovementioned
-        description","number_indents":5,"heading":{"goods_nomenclature_sid":50711,"goods_nomenclature_item_id":"8536000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        apparatus for switching or protecting electrical circuits, or for making connections
-        to or in electrical circuits (for example, switches, relays, fuses, surge
-        suppressors, plugs, sockets, lamp-holders, junction boxes), for a voltage
-        not exceeding&nbsp;1&nbsp;000&nbsp;volts","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        machinery and equipment and parts thereof; sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
-        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96969","_score":1.0,"_source":{"id":96969,"goods_nomenclature_item_id":"8536699088","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"Secure
-        Digital (SD), CompactFlash, \"Smart Card\" and 64- pin PC-card female connectors,
-        of a kind used for soldering on printed circuit boards, for connecting electrical
-        apparatus and circuits and switching or protecting electrical circuits with
-        a voltage of not more than 1 000 V","number_indents":5,"heading":{"goods_nomenclature_sid":50711,"goods_nomenclature_item_id":"8536000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        apparatus for switching or protecting electrical circuits, or for making connections
-        to or in electrical circuits (for example, switches, relays, fuses, surge
-        suppressors, plugs, sockets, lamp-holders, junction boxes), for a voltage
-        not exceeding&nbsp;1&nbsp;000&nbsp;volts","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        machinery and equipment and parts thereof; sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
-        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"50825","_score":1.0,"_source":{"id":50825,"goods_nomenclature_item_id":"8537100000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"For
-        a voltage not exceeding 1&nbsp;000&nbsp;V","number_indents":1,"heading":{"goods_nomenclature_sid":50824,"goods_nomenclature_item_id":"8537000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Boards,
-        panels (including numerical control panels), consoles, desks, cabinets and
-        other bases, equipped with two or more apparatus of heading No  8535&nbsp;or  8536,
-        for electric control or the distribution of electricity, including those incorporating
-        instruments or apparatus of Chapter 90, other than switching apparatus of
-        heading No  8517","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        machinery and equipment and parts thereof; sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
-        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"50842","_score":1.0,"_source":{"id":50842,"goods_nomenclature_item_id":"8537200000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"For
-        a voltage exceeding 1&nbsp;000&nbsp;V","number_indents":1,"heading":{"goods_nomenclature_sid":50824,"goods_nomenclature_item_id":"8537000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Boards,
-        panels (including numerical control panels), consoles, desks, cabinets and
-        other bases, equipped with two or more apparatus of heading No  8535&nbsp;or  8536,
-        for electric control or the distribution of electricity, including those incorporating
-        instruments or apparatus of Chapter 90, other than switching apparatus of
-        heading No  8517","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        machinery and equipment and parts thereof; sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
-        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"50847","_score":1.0,"_source":{"id":50847,"goods_nomenclature_item_id":"8537209100","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Exceeding&nbsp;1&nbsp;000&nbsp;volts
-        but not exceeding&nbsp;72,5&nbsp;kV","number_indents":3,"heading":{"goods_nomenclature_sid":50824,"goods_nomenclature_item_id":"8537000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Boards,
-        panels (including numerical control panels), consoles, desks, cabinets and
-        other bases, equipped with two or more apparatus of heading No  8535&nbsp;or  8536,
-        for electric control or the distribution of electricity, including those incorporating
-        instruments or apparatus of Chapter 90, other than switching apparatus of
-        heading No  8517","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        machinery and equipment and parts thereof; sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
-        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"98050","_score":1.0,"_source":{"id":98050,"goods_nomenclature_item_id":"8538909995","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"Copper
-        base plate, of a kind used as a heatsink in the manufacture of IGBT modules
-        of heading 8535&nbsp;or 8536&nbsp;with a voltage of 650&nbsp;V or more but
-        not more than 1&nbsp;200&nbsp;V","number_indents":5,"heading":{"goods_nomenclature_sid":50853,"goods_nomenclature_item_id":"8538000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Parts
-        suitable for use solely or principally with the apparatus of heading Nos  8535,  8536&nbsp;or  8537","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        machinery and equipment and parts thereof; sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
-        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"87634","_score":1.0,"_source":{"id":87634,"goods_nomenclature_item_id":"8529108020","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"Ceramic
-        filter package comprising 2 ceramic filters and 1 ceramic resonator for a
-        frequency of 10,7 MHz (+/-30 kHz), contained in a housing","number_indents":3,"heading":{"goods_nomenclature_sid":50452,"goods_nomenclature_item_id":"8529000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Parts
-        suitable for use solely or principally with the apparatus of headings&nbsp;8525&nbsp;to
-        8528","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        machinery and equipment and parts thereof; sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
-        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"87642","_score":1.0,"_source":{"id":87642,"goods_nomenclature_item_id":"8529108060","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"Filters,
-        excluding surface acoustic wave filters, for a center frequency of 485 MHz
-        or more but not exceeding 1 990 MHz with an insertion loss not exceeding 3,5
-        dB, contained in a housing","number_indents":3,"heading":{"goods_nomenclature_sid":50452,"goods_nomenclature_item_id":"8529000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Parts
-        suitable for use solely or principally with the apparatus of headings&nbsp;8525&nbsp;to
-        8528","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        machinery and equipment and parts thereof; sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
-        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97551","_score":1.0,"_source":{"id":97551,"goods_nomenclature_item_id":"8529909270","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"Rectangular
-        fastening and covering frame:<br/>-&nbsp;of an aluminium alloy containing
-        silicon and magnesium,<br/>-&nbsp;with a length of&nbsp;900&nbsp;mm or more
-        but not more than 1&nbsp;500&nbsp;mm,<br/>-&nbsp;with a width of 600&nbsp;mm
-        or more but not more than 950&nbsp;mm,<br/>of a kind used for the production&nbsp;of
-        TV sets","number_indents":5,"heading":{"goods_nomenclature_sid":50452,"goods_nomenclature_item_id":"8529000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Parts
-        suitable for use solely or principally with the apparatus of headings&nbsp;8525&nbsp;to
-        8528","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        machinery and equipment and parts thereof; sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
-        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97550","_score":1.0,"_source":{"id":97550,"goods_nomenclature_item_id":"8525801945","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"Camera
-        module with a resolution of 1&nbsp;280&nbsp;*&nbsp;720&nbsp;P&nbsp;HD, with
-        two microphones, for use in the manufacture of products of heading 8528","number_indents":4,"heading":{"goods_nomenclature_sid":50280,"goods_nomenclature_item_id":"8525000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Transmission
-        apparatus for radio-telephony, radio-telegraphy, radio-broadcasting or television,
-        whether or not incorporating reception apparatus or sound recording or reproducing
-        apparatus; television cameras","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        machinery and equipment and parts thereof; sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
-        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"51113","_score":1.0,"_source":{"id":51113,"goods_nomenclature_item_id":"8541210000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"With
-        a dissipation rate of less than 1&nbsp;W","number_indents":2,"heading":{"goods_nomenclature_sid":51101,"goods_nomenclature_item_id":"8541000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Diodes,
-        transistors and similar semiconductor devices; photosensitive semiconductor
-        devices, including photovoltaic cells whether or not assembled in modules
-        or made up into panels; light-emitting diodes; mounted piezoelectric crystals","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        machinery and equipment and parts thereof; sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
-        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"57611","_score":1.0,"_source":{"id":57611,"goods_nomenclature_item_id":"8408107100","producline_suffix":"10","validity_start_date":"1995-01-01T00:00:00+00:00","validity_end_date":null,"description":"Exceeding
-        500&nbsp;kW but not exceeding 1&nbsp;000&nbsp;kW","number_indents":3,"heading":{"goods_nomenclature_sid":47669,"goods_nomenclature_item_id":"8408000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Compression-ignition
-        internal combustion piston engines (diesel or semi-diesel engines)","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
-        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
-        and mechanical appliances; electrical equipment; parts thereof, sound recorders
-        and reproducers, television image and sound recorders and reproducers, and
-        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"57614","_score":1.0,"_source":{"id":57614,"goods_nomenclature_item_id":"8408108100","producline_suffix":"10","validity_start_date":"1995-01-01T00:00:00+00:00","validity_end_date":null,"description":"Exceeding
-        1&nbsp;000&nbsp;kW but not exceeding 5&nbsp;000&nbsp;kW","number_indents":3,"heading":{"goods_nomenclature_sid":47669,"goods_nomenclature_item_id":"8408000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Compression-ignition
-        internal combustion piston engines (diesel or semi-diesel engines)","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
-        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
-        and mechanical appliances; electrical equipment; parts thereof, sound recorders
-        and reproducers, television image and sound recorders and reproducers, and
-        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"82784","_score":1.0,"_source":{"id":82784,"goods_nomenclature_item_id":"8408908100","producline_suffix":"80","validity_start_date":"2006-01-01T00:00:00+00:00","validity_end_date":null,"description":"Exceeding
-        500&nbsp;kW but not exceeding 1&nbsp;000&nbsp;kW","number_indents":4,"heading":{"goods_nomenclature_sid":47669,"goods_nomenclature_item_id":"8408000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Compression-ignition
-        internal combustion piston engines (diesel or semi-diesel engines)","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
-        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
-        and mechanical appliances; electrical equipment; parts thereof, sound recorders
-        and reproducers, television image and sound recorders and reproducers, and
-        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"82787","_score":1.0,"_source":{"id":82787,"goods_nomenclature_item_id":"8408908500","producline_suffix":"80","validity_start_date":"2006-01-01T00:00:00+00:00","validity_end_date":null,"description":"Exceeding
-        1&nbsp;000&nbsp;kW but not exceeding 5&nbsp;000&nbsp;kW","number_indents":4,"heading":{"goods_nomenclature_sid":47669,"goods_nomenclature_item_id":"8408000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Compression-ignition
-        internal combustion piston engines (diesel or semi-diesel engines)","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
-        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
-        and mechanical appliances; electrical equipment; parts thereof, sound recorders
-        and reproducers, television image and sound recorders and reproducers, and
-        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"47743","_score":1.0,"_source":{"id":47743,"goods_nomenclature_item_id":"8410110000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a power not exceeding 1&nbsp;000&nbsp;kW","number_indents":2,"heading":{"goods_nomenclature_sid":47741,"goods_nomenclature_item_id":"8410000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Hydraulic
-        turbines, water wheels, and regulators therefor","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
-        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
-        and mechanical appliances; electrical equipment; parts thereof, sound recorders
-        and reproducers, television image and sound recorders and reproducers, and
-        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"47744","_score":1.0,"_source":{"id":47744,"goods_nomenclature_item_id":"8410120000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a power exceeding 1&nbsp;000&nbsp;kW but not exceeding 10&nbsp;000&nbsp;kW","number_indents":2,"heading":{"goods_nomenclature_sid":47741,"goods_nomenclature_item_id":"8410000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Hydraulic
-        turbines, water wheels, and regulators therefor","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
-        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
-        and mechanical appliances; electrical equipment; parts thereof, sound recorders
-        and reproducers, television image and sound recorders and reproducers, and
-        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"47765","_score":1.0,"_source":{"id":47765,"goods_nomenclature_item_id":"8411210000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a power not exceeding 1&nbsp;100&nbsp;kW","number_indents":2,"heading":{"goods_nomenclature_sid":47749,"goods_nomenclature_item_id":"8411000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Turbojets,
-        turbopropellers and other gas turbines","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
-        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
-        and mechanical appliances; electrical equipment; parts thereof, sound recorders
-        and reproducers, television image and sound recorders and reproducers, and
-        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"47770","_score":1.0,"_source":{"id":47770,"goods_nomenclature_item_id":"8411220000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a power exceeding 1&nbsp;100&nbsp;kW","number_indents":2,"heading":{"goods_nomenclature_sid":47749,"goods_nomenclature_item_id":"8411000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Turbojets,
-        turbopropellers and other gas turbines","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
-        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
-        and mechanical appliances; electrical equipment; parts thereof, sound recorders
-        and reproducers, television image and sound recorders and reproducers, and
-        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"82822","_score":1.0,"_source":{"id":82822,"goods_nomenclature_item_id":"8411222000","producline_suffix":"80","validity_start_date":"2006-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a power exceeding 1&nbsp;100&nbsp;kW but not exceeding 3&nbsp;730&nbsp;kW","number_indents":3,"heading":{"goods_nomenclature_sid":47749,"goods_nomenclature_item_id":"8411000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Turbojets,
-        turbopropellers and other gas turbines","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
-        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
-        and mechanical appliances; electrical equipment; parts thereof, sound recorders
-        and reproducers, television image and sound recorders and reproducers, and
-        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96925","_score":1.0,"_source":{"id":96925,"goods_nomenclature_item_id":"8411990030","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"Wheel-shaped
-        gas turbine component with blades, of a kind used in turbochargers:<br/>-&nbsp;of
-        a precision-cast nickel based alloy complying with standard DIN G- NiCr13Al16MoNb
-        or DIN NiCo10W10Cr9AlTi or AMS AISI:686,<br/>-&nbsp;with a heat-resistance
-        of not more than 1&nbsp;100&nbsp;\u00b0C;<br/>-&nbsp;with a diameter of 30&nbsp;mm
-        or more, but not more than 80&nbsp;mm;<br/>-&nbsp;with a height of 30&nbsp;mm
-        or more, but not more than 50&nbsp;mm","number_indents":4,"heading":{"goods_nomenclature_sid":47749,"goods_nomenclature_item_id":"8411000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Turbojets,
-        turbopropellers and other gas turbines","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
-        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
-        and mechanical appliances; electrical equipment; parts thereof, sound recorders
-        and reproducers, television image and sound recorders and reproducers, and
-        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"98051","_score":1.0,"_source":{"id":98051,"goods_nomenclature_item_id":"8411990040","producline_suffix":"80","validity_start_date":"2014-01-01T00:00:00+00:00","validity_end_date":null,"description":"Spiral-shaped
-        gas turbine turbocharger component:<br/>-&nbsp;of a stainless alloy,<br/>-&nbsp;with
-        a heat-resistance of not more than 1&nbsp;050&nbsp;\u00b0C,<br/>-&nbsp;with
-        a diameter of 100&nbsp;mm or more, but not more than 200&nbsp;mm,<br/>-&nbsp;with
-        a height of 100&nbsp;mm or more, but not more than 150&nbsp;mm,<br/>-&nbsp;whether
-        or not with an engine exhaust manifold","number_indents":4,"heading":{"goods_nomenclature_sid":47749,"goods_nomenclature_item_id":"8411000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Turbojets,
-        turbopropellers and other gas turbines","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
-        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
-        and mechanical appliances; electrical equipment; parts thereof, sound recorders
-        and reproducers, television image and sound recorders and reproducers, and
-        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"86553","_score":1.0,"_source":{"id":86553,"goods_nomenclature_item_id":"8414900050","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"Cross-flow
-        fan, of 97.4&nbsp;mm (\u00b1&nbsp;0.2&nbsp;mm) diameter and 645&nbsp;mm (\u00b11&nbsp;mm)
-        or 873&nbsp;mm (+0.5/-1&nbsp;mm) height made from anti-static, anti-bacterial
-        and heat-resistant, glass fiber reinforced plastic with a minimum temperature
-        resistance of 70&nbsp;\u00b0C, for use in the manufacture of indoor air conditioning
-        units","number_indents":2,"heading":{"goods_nomenclature_sid":47902,"goods_nomenclature_item_id":"8414000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Air
-        or vacuum pumps, air or other gas compressors and fans; ventilating or recycling
-        hoods incorporating a fan, whether or not fitted with filters","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
-        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
-        and mechanical appliances; electrical equipment; parts thereof, sound recorders
-        and reproducers, television image and sound recorders and reproducers, and
-        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"88920","_score":1.0,"_source":{"id":88920,"goods_nomenclature_item_id":"6902900010","producline_suffix":"80","validity_start_date":"2008-01-01T00:00:00+00:00","validity_end_date":null,"description":"Refractory
-        bricks with<br/>- an edge length of more than 300 mm and<br/>- a TiO<sub>2</sub>
-        content of not more than 1% by weight and <br/>- a Al<sub>2</sub>O<sub>3</sub>
-        content of not more than 0.4% by weight and <br/>- a change in volume of less
-        than 9% at 1700\u00b0C","number_indents":2,"heading":{"goods_nomenclature_sid":44315,"goods_nomenclature_item_id":"6902000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Refractory
-        bricks, blocks, tiles and similar refractory ceramic constructional goods,
-        other than those of siliceous fossil meals or similar siliceous earths","number_indents":0},"chapter":{"goods_nomenclature_sid":44310,"goods_nomenclature_item_id":"6900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Ceramic
-        products"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
-        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96911","_score":1.0,"_source":{"id":96911,"goods_nomenclature_item_id":"6909190015","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"Ceramic
-        ring with rectangular transversal section having an external diameter of 19&nbsp;mm
-        or more (+&nbsp;0,00&nbsp;mm/-&nbsp;0,10&nbsp;mm) but not more than 29&nbsp;mm
-        (+ 0,00&nbsp;mm/-&nbsp;0,20&nbsp;mm), an internal diameter of 10&nbsp;mm or
-        more (+&nbsp;0,00&nbsp;mm/- 0,20&nbsp;mm) but not more than 19&nbsp;mm (+
-        0,00&nbsp;mm/-0,30&nbsp;mm), a thickness variable from 2&nbsp;mm (\u00b1&nbsp;0,10&nbsp;mm)
-        to 3,70&nbsp;mm (\u00b1 0,20&nbsp;mm) and heat resistance 240&nbsp;\u00b0C
-        or more, containing by weight:<br/>-&nbsp;90% (\u00b1&nbsp;1,5%) of aluminium
-        oxide<br/>-&nbsp;7% (\u00b1&nbsp;1%) of titanium oxide","number_indents":3,"heading":{"goods_nomenclature_sid":44372,"goods_nomenclature_item_id":"6909000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Ceramic
-        wares for laboratory, chemical or other technical uses; ceramic troughs, tubs
-        and similar receptacles of a kind used in agriculture; ceramic pots, jars
-        and similar articles of a kind used for the conveyance or packing of goods","number_indents":0},"chapter":{"goods_nomenclature_sid":44310,"goods_nomenclature_item_id":"6900000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Ceramic
-        products"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
-        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93584","_score":1.0,"_source":{"id":93584,"goods_nomenclature_item_id":"7009910010","producline_suffix":"80","validity_start_date":"2011-07-01T00:00:00+00:00","validity_end_date":null,"description":"Unframed
-        glass mirrors with: <br/>-&nbsp;a length of 1516&nbsp;(\u00b1&nbsp;1&nbsp;mm);
-        <br/>-&nbsp;a width of 553&nbsp;(\u00b1&nbsp;1&nbsp;mm); <br/>-&nbsp;a thickness
-        of 3&nbsp;(\u00b1 0.1&nbsp;mm); <br/>-&nbsp;the back of the mirror covered
-        with protective polyethylene (PE) film, with a thickness of 0,11&nbsp;mm or
-        more but not more than&nbsp;0,13&nbsp;mm; <br/>-&nbsp;a lead content of not
-        more than 90&nbsp;mg/kg and <br/>-&nbsp;a corrosion resistance of 72&nbsp;hours
-        or more according to ISO&nbsp;9227&nbsp;salt spray test","number_indents":3,"heading":{"goods_nomenclature_sid":44517,"goods_nomenclature_item_id":"7009000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Glass
-        mirrors, whether or not framed, including rear-view mirrors","number_indents":0},"chapter":{"goods_nomenclature_sid":44408,"goods_nomenclature_item_id":"7000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Glass
-        and glassware"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
-        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"74013","_score":1.0,"_source":{"id":74013,"goods_nomenclature_item_id":"7010904100","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+00:00","validity_end_date":null,"description":"1&nbsp;l
-        or more","number_indents":8,"heading":{"goods_nomenclature_sid":44522,"goods_nomenclature_item_id":"7010000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Carboys,
-        bottles, flasks, jars, pots, phials, ampoules and other containers, of glass,
-        of a kind used for the conveyance or packing of goods; preserving jars of
-        glass; stoppers, lids and other closures, of glass","number_indents":0},"chapter":{"goods_nomenclature_sid":44408,"goods_nomenclature_item_id":"7000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Glass
-        and glassware"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
-        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"74014","_score":1.0,"_source":{"id":74014,"goods_nomenclature_item_id":"7010904300","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+00:00","validity_end_date":null,"description":"More
-        than 0,33&nbsp;l but less than 1&nbsp;l","number_indents":8,"heading":{"goods_nomenclature_sid":44522,"goods_nomenclature_item_id":"7010000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Carboys,
-        bottles, flasks, jars, pots, phials, ampoules and other containers, of glass,
-        of a kind used for the conveyance or packing of goods; preserving jars of
-        glass; stoppers, lids and other closures, of glass","number_indents":0},"chapter":{"goods_nomenclature_sid":44408,"goods_nomenclature_item_id":"7000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Glass
-        and glassware"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
-        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"74022","_score":1.0,"_source":{"id":74022,"goods_nomenclature_item_id":"7010905100","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+00:00","validity_end_date":null,"description":"1&nbsp;l
-        or more","number_indents":8,"heading":{"goods_nomenclature_sid":44522,"goods_nomenclature_item_id":"7010000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Carboys,
-        bottles, flasks, jars, pots, phials, ampoules and other containers, of glass,
-        of a kind used for the conveyance or packing of goods; preserving jars of
-        glass; stoppers, lids and other closures, of glass","number_indents":0},"chapter":{"goods_nomenclature_sid":44408,"goods_nomenclature_item_id":"7000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Glass
-        and glassware"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
-        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"74023","_score":1.0,"_source":{"id":74023,"goods_nomenclature_item_id":"7010905300","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+00:00","validity_end_date":null,"description":"More
-        than 0,33&nbsp;l but less than 1&nbsp;l","number_indents":8,"heading":{"goods_nomenclature_sid":44522,"goods_nomenclature_item_id":"7010000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Carboys,
-        bottles, flasks, jars, pots, phials, ampoules and other containers, of glass,
-        of a kind used for the conveyance or packing of goods; preserving jars of
-        glass; stoppers, lids and other closures, of glass","number_indents":0},"chapter":{"goods_nomenclature_sid":44408,"goods_nomenclature_item_id":"7000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Glass
-        and glassware"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
-        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"44631","_score":1.0,"_source":{"id":44631,"goods_nomenclature_item_id":"7018200000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Glass
-        microspheres not exceeding 1&nbsp;mm in diameter","number_indents":1,"heading":{"goods_nomenclature_sid":44621,"goods_nomenclature_item_id":"7018000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Glass
-        beads, imitation pearls, imitation precious or semi-precious stones and similar
-        glass smallwares, and articles thereof other than imitation jewellery; glass
-        eyes other than prosthetic articles; statuettes and other ornaments of lamp-worked
-        glass, other than imitation jewellery; glass microspheres not exceeding 1&nbsp;mm
-        in diameter","number_indents":0},"chapter":{"goods_nomenclature_sid":44408,"goods_nomenclature_item_id":"7000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Glass
-        and glassware"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
-        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96915","_score":1.0,"_source":{"id":96915,"goods_nomenclature_item_id":"7019120005","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"Rovings
-        ranging from 1&nbsp;980&nbsp;to 2&nbsp;033&nbsp;tex, composed of continuous
-        glass filaments of 9&nbsp;\u03bcm (\u00b1&nbsp;0,5&nbsp;\u00b5m)","number_indents":4,"heading":{"goods_nomenclature_sid":44635,"goods_nomenclature_item_id":"7019000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Glass
-        fibres (including glass wool) and articles thereof (for example, yarn, woven
-        fabrics)","number_indents":0},"chapter":{"goods_nomenclature_sid":44408,"goods_nomenclature_item_id":"7000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Glass
-        and glassware"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
-        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96916","_score":1.0,"_source":{"id":96916,"goods_nomenclature_item_id":"7019120025","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"Rovings
-        ranging from 1&nbsp;980&nbsp;to 2&nbsp;033&nbsp;tex, composed of continuous
-        glass filaments of 9&nbsp;\u03bcm (\u00b1&nbsp;0,5&nbsp;\u00b5m)","number_indents":4,"heading":{"goods_nomenclature_sid":44635,"goods_nomenclature_item_id":"7019000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Glass
-        fibres (including glass wool) and articles thereof (for example, yarn, woven
-        fabrics)","number_indents":0},"chapter":{"goods_nomenclature_sid":44408,"goods_nomenclature_item_id":"7000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Glass
-        and glassware"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
-        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96912","_score":1.0,"_source":{"id":96912,"goods_nomenclature_item_id":"7019191015","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"S-glass
-        yarn of 33 tex or a multiple of 33 tex (\u00b1 13%) made from continuous spun-glass
-        filaments with fibres of a diameter of 9 \u00b5m (- 1 \u00b5m / + 1,5 \u00b5m)","number_indents":4,"heading":{"goods_nomenclature_sid":44635,"goods_nomenclature_item_id":"7019000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Glass
-        fibres (including glass wool) and articles thereof (for example, yarn, woven
-        fabrics)","number_indents":0},"chapter":{"goods_nomenclature_sid":44408,"goods_nomenclature_item_id":"7000000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Glass
-        and glassware"},"section":{"numeral":"XIII","title":"Articles of stone, plaster,
-        cement, asbestos, mica or similar materials; ceramic products; glass and glassware","position":13}}},{"_index":"tariff-commodities","_type":"commodity","_id":"44815","_score":1.0,"_source":{"id":44815,"goods_nomenclature_item_id":"7201101100","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
-        by weight 1% or less of silicon","number_indents":3,"heading":{"goods_nomenclature_sid":44812,"goods_nomenclature_item_id":"7201000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Pig
-        iron and spiegeleisen in pigs, blocks or other primary forms","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
-        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
-        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"44816","_score":1.0,"_source":{"id":44816,"goods_nomenclature_item_id":"7201101900","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
-        by weight more than 1% of silicon","number_indents":3,"heading":{"goods_nomenclature_sid":44812,"goods_nomenclature_item_id":"7201000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Pig
-        iron and spiegeleisen in pigs, blocks or other primary forms","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
-        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
-        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"86539","_score":1.0,"_source":{"id":86539,"goods_nomenclature_item_id":"7201103010","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"Pig
-        iron ingots with a length of not more than 350&nbsp;mm, a width of not more
-        than 150&nbsp;mm, a height of not more than 150&nbsp;mm, containing by weight
-        not more than 1% of silicon","number_indents":3,"heading":{"goods_nomenclature_sid":44812,"goods_nomenclature_item_id":"7201000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Pig
-        iron and spiegeleisen in pigs, blocks or other primary forms","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
-        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
-        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"60034","_score":1.0,"_source":{"id":60034,"goods_nomenclature_item_id":"7201501000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Alloy
-        pig iron containing by weight not less than 0,3% but not more than 1% of titanium
-        and not less than 0,5% but not more than 1% of vanadium","number_indents":2,"heading":{"goods_nomenclature_sid":44812,"goods_nomenclature_item_id":"7201000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Pig
-        iron and spiegeleisen in pigs, blocks or other primary forms","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
-        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
-        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90044","_score":1.0,"_source":{"id":90044,"goods_nomenclature_item_id":"7607119020","producline_suffix":"80","validity_start_date":"2008-07-01T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
-        and magnesium alloy strip:<br/>-&nbsp;in rolls,<br/>-&nbsp;of a thickness
-        of 0,14&nbsp;mm or more but not more than 0,40&nbsp;mm,<br/>-&nbsp;a width
-        of 12,5&nbsp;mm or more but not more than 359&nbsp;mm,<br/>-&nbsp;a tensile
-        strength of 285&nbsp;N/mm<sup>2</sup>&nbsp;or more, and<br/>-&nbsp;an elongation
-        at break of 1% or more, and<br/>containing by weight:<br/>-&nbsp;93,3% or
-        more of aluminium,<br/>-&nbsp;2,2% or more but not more than 5% of magnesium,
-        and<br/>-&nbsp;not more than 1,8% of other elements","number_indents":4,"heading":{"goods_nomenclature_sid":47004,"goods_nomenclature_item_id":"7607000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
-        foil (whether or not printed or backed with paper, paperboard, plastics or
-        similar backing materials) of a thickness (excluding any backing) not exceeding
-        0,2&nbsp;mm","number_indents":0},"chapter":{"goods_nomenclature_sid":46925,"goods_nomenclature_item_id":"7600000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
-        and articles thereof"},"section":{"numeral":"XV","title":"Base metals and
-        articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"60940","_score":1.0,"_source":{"id":60940,"goods_nomenclature_item_id":"7616999030","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Plates
-        and sheets of variable thickness of widths of 1&nbsp;200&nbsp;mm or more,
-        for use in certain types of aircraft","number_indents":4,"heading":{"goods_nomenclature_sid":47069,"goods_nomenclature_item_id":"7616000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        articles of aluminium","number_indents":0},"chapter":{"goods_nomenclature_sid":46925,"goods_nomenclature_item_id":"7600000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
-        and articles thereof"},"section":{"numeral":"XV","title":"Base metals and
-        articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"74804","_score":1.0,"_source":{"id":74804,"goods_nomenclature_item_id":"7616999060","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+00:00","validity_end_date":null,"description":"Disc
-        (target) with deposition material, consisting of molybdenum silicide:<br/>-
-        containing 1&nbsp;mg/kg or less of sodium<br/>and<br/>- mounted on a metal
-        support","number_indents":5,"heading":{"goods_nomenclature_sid":47069,"goods_nomenclature_item_id":"7616000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        articles of aluminium","number_indents":0},"chapter":{"goods_nomenclature_sid":46925,"goods_nomenclature_item_id":"7600000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
-        and articles thereof"},"section":{"numeral":"XV","title":"Base metals and
-        articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97552","_score":1.0,"_source":{"id":97552,"goods_nomenclature_item_id":"7616999075","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"Parts
-        in the shape of a rectangular frame:<br/>-&nbsp;of painted aluminium,<br/>-&nbsp;with
-        a length of&nbsp;1&nbsp;011&nbsp;mm or more but not more than 1&nbsp;500&nbsp;mm,<br/>-&nbsp;with
-        a width of 622&nbsp;mm or more but not more than 900&nbsp;mm,<br/>-&nbsp;with
-        a thickness of 0,6&nbsp;mm (\u00b1 0,1&nbsp;mm),<br/>of a kind used in the
-        manufacture of TV sets","number_indents":5,"heading":{"goods_nomenclature_sid":47069,"goods_nomenclature_item_id":"7616000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        articles of aluminium","number_indents":0},"chapter":{"goods_nomenclature_sid":46925,"goods_nomenclature_item_id":"7600000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
-        and articles thereof"},"section":{"numeral":"XV","title":"Base metals and
-        articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"55267","_score":1.0,"_source":{"id":55267,"goods_nomenclature_item_id":"8104900010","producline_suffix":"80","validity_start_date":"1995-01-01T00:00:00+00:00","validity_end_date":null,"description":"Ground
-        and polished magnesium sheets, of dimensions not exceeding&nbsp;1&nbsp;500&times;2&nbsp;000&nbsp;mm,
-        coated on one side eith an epoxy resin insensitive to light","number_indents":2,"heading":{"goods_nomenclature_sid":47181,"goods_nomenclature_item_id":"8104000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Magnesium
-        and articles thereof, including waste and scrap","number_indents":0},"chapter":{"goods_nomenclature_sid":47149,"goods_nomenclature_item_id":"8100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Other
-        base metals; cermets; articles thereof"},"section":{"numeral":"XV","title":"Base
-        metals and articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"97541","_score":1.0,"_source":{"id":97541,"goods_nomenclature_item_id":"8105900010","producline_suffix":"80","validity_start_date":"2013-07-01T00:00:00+00:00","validity_end_date":null,"description":"Bars
-        or wires made of cobalt alloy containing, by weight :<br/>-&nbsp;35% (\u00b1
-        2%) cobalt,<br/>-&nbsp;25% (\u00b1 1%)&nbsp;nickel,<br/>-&nbsp;19% (\u00b1
-        1%) chromium and<br/>-&nbsp;7% (\u00b1 2%) iron<br/>conforming to the material
-        specifications AMS 5842, of a kind used in the aerospace industry","number_indents":2,"heading":{"goods_nomenclature_sid":47197,"goods_nomenclature_item_id":"8105000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Cobalt
-        mattes and other intermediate products of cobalt metallurgy; cobalt and articles
-        thereof, including waste and scrap","number_indents":0},"chapter":{"goods_nomenclature_sid":47149,"goods_nomenclature_item_id":"8100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Other
-        base metals; cermets; articles thereof"},"section":{"numeral":"XV","title":"Base
-        metals and articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"81302","_score":1.0,"_source":{"id":81302,"goods_nomenclature_item_id":"8108300010","producline_suffix":"80","validity_start_date":"2005-01-01T00:00:00+00:00","validity_end_date":null,"description":"Waste
-        and scrap of titanium and titanium alloys, except those containing by weight
-        1% or more but not more than 2% of aluminium","number_indents":2,"heading":{"goods_nomenclature_sid":47208,"goods_nomenclature_item_id":"8108000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Titanium
-        and articles thereof, including waste and scrap","number_indents":0},"chapter":{"goods_nomenclature_sid":47149,"goods_nomenclature_item_id":"8100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Other
-        base metals; cermets; articles thereof"},"section":{"numeral":"XV","title":"Base
-        metals and articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90045","_score":1.0,"_source":{"id":90045,"goods_nomenclature_item_id":"8108903010","producline_suffix":"80","validity_start_date":"2008-07-01T00:00:00+00:00","validity_end_date":null,"description":"Titanium
-        alloy rods complying with standard EN 2002-1&nbsp;or EN 4267","number_indents":3,"heading":{"goods_nomenclature_sid":47208,"goods_nomenclature_item_id":"8108000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Titanium
-        and articles thereof, including waste and scrap","number_indents":0},"chapter":{"goods_nomenclature_sid":47149,"goods_nomenclature_item_id":"8100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Other
-        base metals; cermets; articles thereof"},"section":{"numeral":"XV","title":"Base
-        metals and articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90094","_score":1.0,"_source":{"id":90094,"goods_nomenclature_item_id":"8108903020","producline_suffix":"80","validity_start_date":"2008-07-01T00:00:00+00:00","validity_end_date":null,"description":"Bars,
-        rods and wire of alloy of titanium and aluminium, containing by weight 1%
-        or more but not more than 2% of aluminium, for use in the manufacture of silencers
-        and exhaust pipes of subheadings 8708&nbsp;92&nbsp;or 8714&nbsp;10&nbsp;00","number_indents":3,"heading":{"goods_nomenclature_sid":47208,"goods_nomenclature_item_id":"8108000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Titanium
-        and articles thereof, including waste and scrap","number_indents":0},"chapter":{"goods_nomenclature_sid":47149,"goods_nomenclature_item_id":"8100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Other
-        base metals; cermets; articles thereof"},"section":{"numeral":"XV","title":"Base
-        metals and articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"81304","_score":1.0,"_source":{"id":81304,"goods_nomenclature_item_id":"8108905010","producline_suffix":"80","validity_start_date":"2005-01-01T00:00:00+00:00","validity_end_date":null,"description":"Alloy
-        of titanium and aluminium, containing by weight 1% or more but not more than
-        2% of aluminium, in sheets or rolls, of a thickness of 0,49&nbsp;mm or more
-        but not exceeding 3,1&nbsp;mm, of a width of 1&nbsp;000&nbsp;mm or more but
-        not exceeding 1&nbsp;254&nbsp;mm, for the manufacture of goods of subheading
-        8714&nbsp;19&nbsp;00","number_indents":4,"heading":{"goods_nomenclature_sid":47208,"goods_nomenclature_item_id":"8108000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Titanium
-        and articles thereof, including waste and scrap","number_indents":0},"chapter":{"goods_nomenclature_sid":47149,"goods_nomenclature_item_id":"8100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Other
-        base metals; cermets; articles thereof"},"section":{"numeral":"XV","title":"Base
-        metals and articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96366","_score":1.0,"_source":{"id":96366,"goods_nomenclature_item_id":"8108905070","producline_suffix":"80","validity_start_date":"2012-07-01T00:00:00+00:00","validity_end_date":null,"description":"Strip
-        of an alloy of titanium, containing by weight <br/>\t\t\t\t\t\t<br/>-&nbsp;15%
-        (\u00b1 1%) of vanadium <br/>\t\t\t\t\t\t<br/>-&nbsp;3% (\u00b1 0,5%) of chromium
-        <br/>\t\t\t\t\t\t<br/>-&nbsp;3% (\u00b1 0,5%) of tin and <br/>\t\t\t\t\t\t<br/>-&nbsp;3%
-        (\u00b1 0,5%) of aluminium","number_indents":3,"heading":{"goods_nomenclature_sid":47208,"goods_nomenclature_item_id":"8108000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Titanium
-        and articles thereof, including waste and scrap","number_indents":0},"chapter":{"goods_nomenclature_sid":47149,"goods_nomenclature_item_id":"8100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Other
-        base metals; cermets; articles thereof"},"section":{"numeral":"XV","title":"Base
-        metals and articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"76694","_score":1.0,"_source":{"id":76694,"goods_nomenclature_item_id":"8309909010","producline_suffix":"80","validity_start_date":"2003-07-01T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
-        can ends with so-called \"ring pull\" full aperture with a diameter of 136,5&nbsp;mm&nbsp;(+/-&nbsp;1&nbsp;mm)","number_indents":3,"heading":{"goods_nomenclature_sid":47558,"goods_nomenclature_item_id":"8309000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Stoppers,
-        caps and lids (including crown corks, screw caps and pouring stoppers), capsules
-        for bottles, threaded bungs, bung covers, seals and other packing accessories,
-        of base metal","number_indents":0},"chapter":{"goods_nomenclature_sid":47491,"goods_nomenclature_item_id":"8300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Miscellaneous
-        articles of base metal"},"section":{"numeral":"XV","title":"Base metals and
-        articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"47649","_score":1.0,"_source":{"id":47649,"goods_nomenclature_item_id":"8407330000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a cylinder capacity exceeding&nbsp;250&nbsp;cc but not exceeding&nbsp;1&nbsp;000&nbsp;cc","number_indents":2,"heading":{"goods_nomenclature_sid":47621,"goods_nomenclature_item_id":"8407000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Spark-ignition
-        reciprocating or rotary internal combustion piston engines","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
-        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
-        and mechanical appliances; electrical equipment; parts thereof, sound recorders
-        and reproducers, television image and sound recorders and reproducers, and
-        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"47652","_score":1.0,"_source":{"id":47652,"goods_nomenclature_item_id":"8407340000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a cylinder capacity exceeding 1&nbsp;000&nbsp;cm<sup>3</sup>","number_indents":2,"heading":{"goods_nomenclature_sid":47621,"goods_nomenclature_item_id":"8407000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Spark-ignition
-        reciprocating or rotary internal combustion piston engines","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
-        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
-        and mechanical appliances; electrical equipment; parts thereof, sound recorders
-        and reproducers, television image and sound recorders and reproducers, and
-        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"47657","_score":1.0,"_source":{"id":47657,"goods_nomenclature_item_id":"8407349100","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Not
-        exceeding 1&nbsp;500&nbsp;cm<sup>3</sup>","number_indents":5,"heading":{"goods_nomenclature_sid":47621,"goods_nomenclature_item_id":"8407000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Spark-ignition
-        reciprocating or rotary internal combustion piston engines","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
-        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
-        and mechanical appliances; electrical equipment; parts thereof, sound recorders
-        and reproducers, television image and sound recorders and reproducers, and
-        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"47658","_score":1.0,"_source":{"id":47658,"goods_nomenclature_item_id":"8407349900","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Exceeding
-        1&nbsp;500&nbsp;cm<sup>3</sup>","number_indents":5,"heading":{"goods_nomenclature_sid":47621,"goods_nomenclature_item_id":"8407000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Spark-ignition
-        reciprocating or rotary internal combustion piston engines","number_indents":0},"chapter":{"goods_nomenclature_sid":47571,"goods_nomenclature_item_id":"8400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Nuclear
-        reactors, boilers, machinery and mechanical appliances; parts thereof"},"section":{"numeral":"XVI","title":"Machinery
-        and mechanical appliances; electrical equipment; parts thereof, sound recorders
-        and reproducers, television image and sound recorders and reproducers, and
-        parts and accessories of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"46329","_score":1.0,"_source":{"id":46329,"goods_nomenclature_item_id":"7311009100","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Less
-        than 1&nbsp;000&nbsp;l","number_indents":2,"heading":{"goods_nomenclature_sid":46324,"goods_nomenclature_item_id":"7311000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containers
-        for compressed or liquefied gas, of iron or steel","number_indents":0},"chapter":{"goods_nomenclature_sid":46039,"goods_nomenclature_item_id":"7300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Articles
-        of iron or steel"},"section":{"numeral":"XV","title":"Base metals and articles
-        of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"46330","_score":1.0,"_source":{"id":46330,"goods_nomenclature_item_id":"7311009900","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"1&nbsp;000&nbsp;l
-        or more","number_indents":2,"heading":{"goods_nomenclature_sid":46324,"goods_nomenclature_item_id":"7311000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containers
-        for compressed or liquefied gas, of iron or steel","number_indents":0},"chapter":{"goods_nomenclature_sid":46039,"goods_nomenclature_item_id":"7300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Articles
-        of iron or steel"},"section":{"numeral":"XV","title":"Base metals and articles
-        of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"86957","_score":1.0,"_source":{"id":86957,"goods_nomenclature_item_id":"7419999091","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"Disc
-        (target) with deposition material, consisting of molybdenum silicide:<br/>-
-        containing 1&nbsp;mg/kg or less of sodium<br/>and<br/>- mounted on a copper
-        or aluminium support","number_indents":5,"heading":{"goods_nomenclature_sid":46883,"goods_nomenclature_item_id":"7419000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        articles of copper","number_indents":0},"chapter":{"goods_nomenclature_sid":46740,"goods_nomenclature_item_id":"7400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Copper
-        and articles thereof"},"section":{"numeral":"XV","title":"Base metals and
-        articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"93091","_score":1.0,"_source":{"id":93091,"goods_nomenclature_item_id":"7606129220","producline_suffix":"80","validity_start_date":"2011-01-01T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
-        and magnesium alloy strip:<br/>-&nbsp;in rolls,<br/>-&nbsp;of a thickness
-        of 0,14&nbsp;mm or more but not more than 0,40&nbsp;mm,<br/>-&nbsp;a width
-        of 12,5&nbsp;mm or more but not more than 359&nbsp;mm,<br/>-&nbsp;a tensile
-        strength of 285&nbsp;N/mm<sup>2</sup>&nbsp;or more, and<br/>-&nbsp;an elongation
-        at break of 1% or more, and<br/>containing by weight:<br/>-&nbsp;93,3% or
-        more of aluminium,<br/>-&nbsp;2,2% or more but not more than 5% of magnesium,
-        and<br/>-&nbsp;not more than 1,8% of other elements","number_indents":5,"heading":{"goods_nomenclature_sid":46965,"goods_nomenclature_item_id":"7606000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
-        plates, sheets and strip, of a thickness exceeding 0,2&nbsp;mm","number_indents":0},"chapter":{"goods_nomenclature_sid":46925,"goods_nomenclature_item_id":"7600000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Aluminium
-        and articles thereof"},"section":{"numeral":"XV","title":"Base metals and
-        articles of base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"80953","_score":1.0,"_source":{"id":80953,"goods_nomenclature_item_id":"7208521000","producline_suffix":"80","validity_start_date":"2005-01-01T00:00:00+00:00","validity_end_date":null,"description":"Rolled
-        on four faces or in a closed box pass, of a width not exceeding 1&nbsp;250&nbsp;mm","number_indents":3,"heading":{"goods_nomenclature_sid":44986,"goods_nomenclature_item_id":"7208000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Flat-rolled
-        products of iron or non-alloy steel, of a width of 600&nbsp;mm or more, hot-rolled,
-        not clad, plated or coated","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
-        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
-        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"80956","_score":1.0,"_source":{"id":80956,"goods_nomenclature_item_id":"7208531000","producline_suffix":"80","validity_start_date":"2005-01-01T00:00:00+00:00","validity_end_date":null,"description":"Rolled
-        on four faces or in a closed box pass, of a width not exceeding 1&nbsp;250&nbsp;mm
-        and of a thickness of 4&nbsp;mm or more","number_indents":3,"heading":{"goods_nomenclature_sid":44986,"goods_nomenclature_item_id":"7208000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Flat-rolled
-        products of iron or non-alloy steel, of a width of 600&nbsp;mm or more, hot-rolled,
-        not clad, plated or coated","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
-        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
-        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"60077","_score":1.0,"_source":{"id":60077,"goods_nomenclature_item_id":"7209160000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a thickness exceeding 1&nbsp;mm but less than 3&nbsp;mm","number_indents":2,"heading":{"goods_nomenclature_sid":45192,"goods_nomenclature_item_id":"7209000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Flat-rolled
-        products of iron or non-alloy steel, of a width of 600&nbsp;mm or more, cold-rolled
-        (cold-reduced), not clad, plated or coated","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
-        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
-        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"60080","_score":1.0,"_source":{"id":60080,"goods_nomenclature_item_id":"7209170000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a thickness of 0,5&nbsp;mm or more but not exceeding 1&nbsp;mm","number_indents":2,"heading":{"goods_nomenclature_sid":45192,"goods_nomenclature_item_id":"7209000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Flat-rolled
-        products of iron or non-alloy steel, of a width of 600&nbsp;mm or more, cold-rolled
-        (cold-reduced), not clad, plated or coated","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
-        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
-        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"60090","_score":1.0,"_source":{"id":60090,"goods_nomenclature_item_id":"7209260000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a thickness exceeding 1&nbsp;mm but less than 3&nbsp;mm","number_indents":2,"heading":{"goods_nomenclature_sid":45192,"goods_nomenclature_item_id":"7209000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Flat-rolled
-        products of iron or non-alloy steel, of a width of 600&nbsp;mm or more, cold-rolled
-        (cold-reduced), not clad, plated or coated","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
-        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
-        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"60093","_score":1.0,"_source":{"id":60093,"goods_nomenclature_item_id":"7209270000","producline_suffix":"80","validity_start_date":"1996-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a thickness of 0,5&nbsp;mm or more but not exceeding 1&nbsp;mm","number_indents":2,"heading":{"goods_nomenclature_sid":45192,"goods_nomenclature_item_id":"7209000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Flat-rolled
-        products of iron or non-alloy steel, of a width of 600&nbsp;mm or more, cold-rolled
-        (cold-reduced), not clad, plated or coated","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
-        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
-        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"45741","_score":1.0,"_source":{"id":45741,"goods_nomenclature_item_id":"7219330000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a thickness exceeding&nbsp;1&nbsp;mm but less than 3&nbsp;mm","number_indents":2,"heading":{"goods_nomenclature_sid":45704,"goods_nomenclature_item_id":"7219000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Flat-rolled
-        products of stainless steel, of a width of 600&nbsp;mm or more","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
-        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
-        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"45744","_score":1.0,"_source":{"id":45744,"goods_nomenclature_item_id":"7219340000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a thickness of 0,5&nbsp;mm or more but not exceeding&nbsp;1&nbsp;mm","number_indents":2,"heading":{"goods_nomenclature_sid":45704,"goods_nomenclature_item_id":"7219000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Flat-rolled
-        products of stainless steel, of a width of 600&nbsp;mm or more","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
-        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
-        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"45863","_score":1.0,"_source":{"id":45863,"goods_nomenclature_item_id":"7224900500","producline_suffix":"80","validity_start_date":"1993-01-01T00:00:00+00:00","validity_end_date":null,"description":"Containing
-        by weight not more than 0,7% of carbon, 0,5% or more but not more than 1,2%
-        of manganese and 0,6% or more but not more than 2,3% of silicon; containing
-        by weight 0,0008% or more of boron with any other elements less than the minimum
-        content referred to in note 1 f) to this chapter","number_indents":5,"heading":{"goods_nomenclature_sid":45856,"goods_nomenclature_item_id":"7224000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        alloy steel in ingots or other primary forms; semi-finished products of other
-        alloy steel","number_indents":0},"chapter":{"goods_nomenclature_sid":44810,"goods_nomenclature_item_id":"7200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Iron
-        and steel"},"section":{"numeral":"XV","title":"Base metals and articles of
-        base metal","position":15}}},{"_index":"tariff-commodities","_type":"commodity","_id":"43122","_score":1.0,"_source":{"id":43122,"goods_nomenclature_item_id":"6201121000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a weight, per garment, not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":43116,"goods_nomenclature_item_id":"6201000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Men''s
-        or boys'' overcoats, car coats, capes, cloaks, anoraks (including ski jackets),
-        windcheaters, wind-jackets and similar articles, other than those of heading&nbsp;6203","number_indents":0},"chapter":{"goods_nomenclature_sid":43115,"goods_nomenclature_item_id":"6200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Articles
-        of apparel and clothing accessories, not knitted or crocheted"},"section":{"numeral":"XI","title":"Textiles
-        and textile articles","position":11}}},{"_index":"tariff-commodities","_type":"commodity","_id":"43125","_score":1.0,"_source":{"id":43125,"goods_nomenclature_item_id":"6201129000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a weight, per garment, exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":43116,"goods_nomenclature_item_id":"6201000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Men''s
-        or boys'' overcoats, car coats, capes, cloaks, anoraks (including ski jackets),
-        windcheaters, wind-jackets and similar articles, other than those of heading&nbsp;6203","number_indents":0},"chapter":{"goods_nomenclature_sid":43115,"goods_nomenclature_item_id":"6200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Articles
-        of apparel and clothing accessories, not knitted or crocheted"},"section":{"numeral":"XI","title":"Textiles
-        and textile articles","position":11}}},{"_index":"tariff-commodities","_type":"commodity","_id":"43129","_score":1.0,"_source":{"id":43129,"goods_nomenclature_item_id":"6201131000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a weight, per garment, not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":43116,"goods_nomenclature_item_id":"6201000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Men''s
-        or boys'' overcoats, car coats, capes, cloaks, anoraks (including ski jackets),
-        windcheaters, wind-jackets and similar articles, other than those of heading&nbsp;6203","number_indents":0},"chapter":{"goods_nomenclature_sid":43115,"goods_nomenclature_item_id":"6200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Articles
-        of apparel and clothing accessories, not knitted or crocheted"},"section":{"numeral":"XI","title":"Textiles
-        and textile articles","position":11}}},{"_index":"tariff-commodities","_type":"commodity","_id":"43132","_score":1.0,"_source":{"id":43132,"goods_nomenclature_item_id":"6201139000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a weight, per garment, exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":43116,"goods_nomenclature_item_id":"6201000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Men''s
-        or boys'' overcoats, car coats, capes, cloaks, anoraks (including ski jackets),
-        windcheaters, wind-jackets and similar articles, other than those of heading&nbsp;6203","number_indents":0},"chapter":{"goods_nomenclature_sid":43115,"goods_nomenclature_item_id":"6200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Articles
-        of apparel and clothing accessories, not knitted or crocheted"},"section":{"numeral":"XI","title":"Textiles
-        and textile articles","position":11}}},{"_index":"tariff-commodities","_type":"commodity","_id":"43152","_score":1.0,"_source":{"id":43152,"goods_nomenclature_item_id":"6202121000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a weight, per garment, not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":43145,"goods_nomenclature_item_id":"6202000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Women''s
-        or girls'' overcoats, car coats, capes, cloaks, anoraks (including ski jackets),
-        windcheaters, wind-jackets and similar articles, other than those of heading&nbsp;6204","number_indents":0},"chapter":{"goods_nomenclature_sid":43115,"goods_nomenclature_item_id":"6200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Articles
-        of apparel and clothing accessories, not knitted or crocheted"},"section":{"numeral":"XI","title":"Textiles
-        and textile articles","position":11}}},{"_index":"tariff-commodities","_type":"commodity","_id":"43155","_score":1.0,"_source":{"id":43155,"goods_nomenclature_item_id":"6202129000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a weight, per garment, exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":43145,"goods_nomenclature_item_id":"6202000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Women''s
-        or girls'' overcoats, car coats, capes, cloaks, anoraks (including ski jackets),
-        windcheaters, wind-jackets and similar articles, other than those of heading&nbsp;6204","number_indents":0},"chapter":{"goods_nomenclature_sid":43115,"goods_nomenclature_item_id":"6200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Articles
-        of apparel and clothing accessories, not knitted or crocheted"},"section":{"numeral":"XI","title":"Textiles
-        and textile articles","position":11}}},{"_index":"tariff-commodities","_type":"commodity","_id":"43159","_score":1.0,"_source":{"id":43159,"goods_nomenclature_item_id":"6202131000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a weight, per garment, not exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":43145,"goods_nomenclature_item_id":"6202000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Women''s
-        or girls'' overcoats, car coats, capes, cloaks, anoraks (including ski jackets),
-        windcheaters, wind-jackets and similar articles, other than those of heading&nbsp;6204","number_indents":0},"chapter":{"goods_nomenclature_sid":43115,"goods_nomenclature_item_id":"6200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Articles
-        of apparel and clothing accessories, not knitted or crocheted"},"section":{"numeral":"XI","title":"Textiles
-        and textile articles","position":11}}},{"_index":"tariff-commodities","_type":"commodity","_id":"43162","_score":1.0,"_source":{"id":43162,"goods_nomenclature_item_id":"6202139000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
-        a weight, per garment, exceeding 1&nbsp;kg","number_indents":3,"heading":{"goods_nomenclature_sid":43145,"goods_nomenclature_item_id":"6202000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Women''s
-        or girls'' overcoats, car coats, capes, cloaks, anoraks (including ski jackets),
-        windcheaters, wind-jackets and similar articles, other than those of heading&nbsp;6204","number_indents":0},"chapter":{"goods_nomenclature_sid":43115,"goods_nomenclature_item_id":"6200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Articles
-        of apparel and clothing accessories, not knitted or crocheted"},"section":{"numeral":"XI","title":"Textiles
-        and textile articles","position":11}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96974","_score":1.0,"_source":{"id":96974,"goods_nomenclature_item_id":"8544200010","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"PET/PVC
-        insulated flexible cable with:<br/>\u2022\ta voltage of not more than 60 V,<br/>\u2022\ta
-        current of not more than 1 A,<br/>\u2022\ta heat resistance of not more than
-        105 \u00b0C,<br/>\u2022\tindividual wires of a thickness of not more than
-        0,1 mm (\u00b1 0,01 mm) and a width of not more than 0,8 mm (\u00b1 0,03 mm),<br/>\u2022\ta
-        distance between conductors of not more than 0,5 mm and<br/>\u2022\ta pitch
-        (distance from centreline to centreline of conductors) of not more than 1,25
-        mm","number_indents":2,"heading":{"goods_nomenclature_sid":52840,"goods_nomenclature_item_id":"8544000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insulated
-        (including enamelled or anodised) wire, cable (including coaxial cable) and
-        other insulated electric conductors, whether or not fitted with connectors;
-        optical fibre cables, made up of individually sheathed fibres, whether or
-        not assembled with electric conductors or fitted with connectors","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        machinery and equipment and parts thereof; sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
-        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"87974","_score":1.0,"_source":{"id":87974,"goods_nomenclature_item_id":"8544420000","producline_suffix":"10","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        electric conductors, for a voltage not exceeding 1&nbsp;000&nbsp;V","number_indents":1,"heading":{"goods_nomenclature_sid":52840,"goods_nomenclature_item_id":"8544000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insulated
-        (including enamelled or anodised) wire, cable (including coaxial cable) and
-        other insulated electric conductors, whether or not fitted with connectors;
-        optical fibre cables, made up of individually sheathed fibres, whether or
-        not assembled with electric conductors or fitted with connectors","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        machinery and equipment and parts thereof; sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
-        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"91190","_score":1.0,"_source":{"id":91190,"goods_nomenclature_item_id":"8544429010","producline_suffix":"80","validity_start_date":"2009-07-01T00:00:00+00:00","validity_end_date":null,"description":"Data
-        transmission cable capable of a bit rate transmission of 600&nbsp;Mbit/s or
-        more, with:<br/>-&nbsp;a voltage of 1,25&nbsp;V&nbsp;(\u00b1&nbsp;0,25&nbsp;V)<br/>-&nbsp;connectors
-        fitted at one or both ends, at least one of which contains pins with a pitch
-        of&nbsp;1&nbsp;mm,<br/>-&nbsp;outer screening shielding,<br/>used solely for
-        communication between LCD, PDP or OLED panel and video processing electronic
-        circuits","number_indents":4,"heading":{"goods_nomenclature_sid":52840,"goods_nomenclature_item_id":"8544000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insulated
-        (including enamelled or anodised) wire, cable (including coaxial cable) and
-        other insulated electric conductors, whether or not fitted with connectors;
-        optical fibre cables, made up of individually sheathed fibres, whether or
-        not assembled with electric conductors or fitted with connectors","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        machinery and equipment and parts thereof; sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
-        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96975","_score":1.0,"_source":{"id":96975,"goods_nomenclature_item_id":"8544429020","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"PET/PVC
-        insulated flexible cable with:<br/>\u2022\ta voltage of not more than 60 V,<br/>\u2022\ta
-        current of not more than 1 A,<br/>\u2022\ta heat resistance of not more than
-        105 \u00b0C,<br/>\u2022\tindividual wires of a thickness of not more than
-        0,1 mm (\u00b1 0,01 mm) and a width of not more than 0,8 mm (\u00b1 0,03 mm),<br/>\u2022\ta
-        distance between conductors of not more than 0,5 mm and<br/>\u2022\ta pitch
-        (distance from centreline to centreline of conductors) of not more than 1,25
-        mm","number_indents":4,"heading":{"goods_nomenclature_sid":52840,"goods_nomenclature_item_id":"8544000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insulated
-        (including enamelled or anodised) wire, cable (including coaxial cable) and
-        other insulated electric conductors, whether or not fitted with connectors;
-        optical fibre cables, made up of individually sheathed fibres, whether or
-        not assembled with electric conductors or fitted with connectors","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        machinery and equipment and parts thereof; sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
-        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"90675","_score":1.0,"_source":{"id":90675,"goods_nomenclature_item_id":"8544499320","producline_suffix":"80","validity_start_date":"2009-01-01T00:00:00+00:00","validity_end_date":null,"description":"PET/PVC
-        insulated flexible cable with:<br/>-&nbsp;a voltage of not more than 60&nbsp;V,<br/>-&nbsp;a
-        current of not more than 1&nbsp;A<br/>-&nbsp;a heat resistance of not more
-        than 105\u00b0C,<br/>-&nbsp;individual wires of a thickness of 0,05&nbsp;mm
-        (\u00b1&nbsp;0,01&nbsp;mm) and a width of not more than 0,65&nbsp;mm (\u00b1&nbsp;0,03&nbsp;mm)<br/>-&nbsp;distance
-        between conductors of not more than 0,5&nbsp;mm and<br/>-&nbsp;pitch (distance
-        from centreline to centreline of conductors) of not more than 1,08&nbsp;mm","number_indents":6,"heading":{"goods_nomenclature_sid":52840,"goods_nomenclature_item_id":"8544000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insulated
-        (including enamelled or anodised) wire, cable (including coaxial cable) and
-        other insulated electric conductors, whether or not fitted with connectors;
-        optical fibre cables, made up of individually sheathed fibres, whether or
-        not assembled with electric conductors or fitted with connectors","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        machinery and equipment and parts thereof; sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
-        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"87982","_score":1.0,"_source":{"id":87982,"goods_nomenclature_item_id":"8544499500","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"For
-        a voltage exceeding 80&nbsp;V but less than 1&nbsp;000&nbsp;V","number_indents":5,"heading":{"goods_nomenclature_sid":52840,"goods_nomenclature_item_id":"8544000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insulated
-        (including enamelled or anodised) wire, cable (including coaxial cable) and
-        other insulated electric conductors, whether or not fitted with connectors;
-        optical fibre cables, made up of individually sheathed fibres, whether or
-        not assembled with electric conductors or fitted with connectors","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        machinery and equipment and parts thereof; sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
-        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"96977","_score":1.0,"_source":{"id":96977,"goods_nomenclature_item_id":"8544499510","producline_suffix":"80","validity_start_date":"2013-01-01T00:00:00+00:00","validity_end_date":null,"description":"PET/PVC
-        insulated flexible cable with:<br/>\u2022\ta voltage of not more than 60 V,<br/>\u2022\ta
-        current of not more than 1 A,<br/>\u2022\ta heat resistance of not more than
-        105 \u00b0C,<br/>\u2022\tindividual wires of a thickness of not more than
-        0,1 mm (\u00b1 0,01 mm) and a width of not more than 0,8 mm (\u00b1 0,03 mm),<br/>\u2022\ta
-        distance between conductors of not more than 0,5 mm and<br/>\u2022\ta pitch
-        (distance from centreline to centreline of conductors) of not more than 1,25
-        mm","number_indents":6,"heading":{"goods_nomenclature_sid":52840,"goods_nomenclature_item_id":"8544000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insulated
-        (including enamelled or anodised) wire, cable (including coaxial cable) and
-        other insulated electric conductors, whether or not fitted with connectors;
-        optical fibre cables, made up of individually sheathed fibres, whether or
-        not assembled with electric conductors or fitted with connectors","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        machinery and equipment and parts thereof; sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
-        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"87983","_score":1.0,"_source":{"id":87983,"goods_nomenclature_item_id":"8544499900","producline_suffix":"80","validity_start_date":"2007-01-01T00:00:00+00:00","validity_end_date":null,"description":"For
-        a voltage of 1&nbsp;000&nbsp;V","number_indents":5,"heading":{"goods_nomenclature_sid":52840,"goods_nomenclature_item_id":"8544000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insulated
-        (including enamelled or anodised) wire, cable (including coaxial cable) and
-        other insulated electric conductors, whether or not fitted with connectors;
-        optical fibre cables, made up of individually sheathed fibres, whether or
-        not assembled with electric conductors or fitted with connectors","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        machinery and equipment and parts thereof; sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
-        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"52884","_score":1.0,"_source":{"id":52884,"goods_nomenclature_item_id":"8544600000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Other
-        electric conductors, for a voltage exceeding 1&nbsp;000&nbsp;V","number_indents":1,"heading":{"goods_nomenclature_sid":52840,"goods_nomenclature_item_id":"8544000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Insulated
-        (including enamelled or anodised) wire, cable (including coaxial cable) and
-        other insulated electric conductors, whether or not fitted with connectors;
-        optical fibre cables, made up of individually sheathed fibres, whether or
-        not assembled with electric conductors or fitted with connectors","number_indents":0},"chapter":{"goods_nomenclature_sid":49496,"goods_nomenclature_item_id":"8500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+00:00","validity_end_date":null,"description":"Electrical
-        machinery and equipment and parts thereof; sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
-        of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
-        appliances; electrical equipment; parts thereof, sound recorders and reproducers,
-        television image and sound recorders and reproducers, and parts and accessories
         of such articles","position":16}}},{"_index":"tariff-commodities","_type":"commodity","_id":"53060","_score":1.0,"_source":{"id":53060,"goods_nomenclature_item_id":"8703210000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Of
         a cylinder capacity not exceeding 1&nbsp;000&nbsp;cm<sup>3</sup>","number_indents":2,"heading":{"goods_nomenclature_sid":53053,"goods_nomenclature_item_id":"8703000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+00:00","validity_end_date":null,"description":"Motor
         cars and other motor vehicles principally designed for the transport of persons
@@ -3550,13 +3548,11 @@ http_interactions:
         of such articles"},"section":{"numeral":"XVI","title":"Machinery and mechanical
         appliances; electrical equipment; parts thereof, sound recorders and reproducers,
         television image and sound recorders and reproducers, and parts and accessories
-        of such articles","position":16}}}],"sections":[]},"reference_match":{"chapters":[],"commodities":[],"headings":[],"sections":[{"_index":"tariff-search_references","_type":"search_reference","_id":"7004","_score":8.129246,"_source":{"title":"synonym
-        1","reference_class":"Section","reference":{"id":1,"numeral":"I","title":"Live
-        animals; animal products","position":1,"class":"Section"}}},{"_index":"tariff-search_references","_type":"search_reference","_id":"7005","_score":8.129246,"_source":{"title":"synonym
+        of such articles","position":16}}}],"sections":[]},"reference_match":{"chapters":[],"commodities":[],"headings":[],"sections":[{"_index":"tariff-search_references","_type":"search_reference","_id":"7004","_score":7.79958,"_source":{"title":"synonym
         1","reference_class":"Section","reference":{"id":1,"numeral":"I","title":"Live
         animals; animal products","position":1,"class":"Section"}}}]}}'
     http_version: 
-  recorded_at: Tue, 15 Apr 2014 18:41:01 GMT
+  recorded_at: Fri, 18 Apr 2014 14:33:12 GMT
 - request:
     method: get
     uri: http://tariff-api.dev.gov.uk/geographical_areas/countries
@@ -3575,7 +3571,7 @@ http_interactions:
         bmdpbng=
       !binary "RGF0ZQ==":
       - !binary |-
-        VHVlLCAxNSBBcHIgMjAxNCAxODo0MTowMyBHTVQ=
+        RnJpLCAxOCBBcHIgMjAxNCAxNDozMzoxMyBHTVQ=
       !binary "Q29udGVudC1UeXBl":
       - !binary |-
         YXBwbGljYXRpb24vanNvbjsgY2hhcnNldD11dGYtOA==
@@ -3588,9 +3584,6 @@ http_interactions:
       !binary "U3RhdHVz":
       - !binary |-
         MjAwIE9L
-      !binary "WC1NZXRhLVJlcXVlc3QtVmVyc2lvbg==":
-      - !binary |-
-        MC4yLjk=
       !binary "WC1VYS1Db21wYXRpYmxl":
       - !binary |-
         SUU9RWRnZQ==
@@ -3602,10 +3595,10 @@ http_interactions:
         bWF4LWFnZT0wLCBwcml2YXRlLCBtdXN0LXJldmFsaWRhdGU=
       !binary "WC1SZXF1ZXN0LUlk":
       - !binary |-
-        MDUzMzQxMjYzNTNhNzRjNDNjYTIzNmZlNzhiOWM3MDE=
+        YWUyOTllYzViODExYmU4NGMzMDlhNTZlMTE0NDY4MjI=
       !binary "WC1SdW50aW1l":
       - !binary |-
-        MC41MDY5ODk=
+        MC42MjMxMjA=
       !binary "WC1GcmFtZS1PcHRpb25z":
       - !binary |-
         U0FNRU9SSUdJTg==
@@ -3860,5 +3853,5 @@ http_interactions:
         cmlwdGlvbiI6IkhpZ2ggc2VhcyAoTWFyaXRpbWUgZG9tYWluIG91dHNpZGUg
         b2YgdGVycml0b3JpYWwgd2F0ZXJzKSJ9XQ==
     http_version: 
-  recorded_at: Tue, 15 Apr 2014 18:41:03 GMT
+  recorded_at: Fri, 18 Apr 2014 14:33:13 GMT
 recorded_with: VCR 2.5.0


### PR DESCRIPTION
> If we assign two synonyms to the same location (heading, commodity) when we search the result appears twice.
> We should dedup the response, so we only show one result, per location.

[pivotal story](https://www.pivotaltracker.com/n/projects/488191/stories/68999382)
