### PR TITLE
Use `X-Robots-Tag` header in controllers that inherit from `ApplicationController`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::Base
   before_filter :set_cache
   before_filter :load_artefact
   before_filter :search_query
+  before_filter :bots_no_index_if_historical
 
   after_filter :set_app_slimmer_headers
 
@@ -82,5 +83,11 @@ class ApplicationController < ActionController::Base
         remove_meta_viewport: true
       )
     end
+  end
+
+  protected
+
+  def bots_no_index_if_historical
+    response.headers["X-Robots-Tag"] = "none" unless @search.today?
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,8 +1,6 @@
 require 'addressable/uri'
 
 class SearchController < ApplicationController
-  before_filter :bots_no_index_if_historical, only: :search
-
   def search
     @results = @search.perform
 
@@ -30,11 +28,5 @@ class SearchController < ApplicationController
 
       format.atom
     end
-  end
-
-  private
-
-  def bots_no_index_if_historical
-    response.headers["X-Robots-Tag"] = "none" unless @search.today?
   end
 end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe SearchController, "GET to #search" do
+  include CrawlerCommons
+
   context 'with HTML format' do
     context 'with search term' do
       context "with exact match query", vcr: { cassette_name: "search#search_exact" }  do
@@ -196,19 +198,12 @@ describe SearchController, "GET to #search" do
   describe "header for crawlers", vcr: { cassette_name: "search#blank_match" } do
     context "non historical" do
       before { get :search }
-
-      it "should not include X-Robots-Tag" do
-        expect(response.headers["X-Robots-Tag"]).to_not be_present
-      end
+      it { should_not_include_robots_tag! }
     end
-    context "historical" do
-      before {
-        get :search, {month: 1, year: 2008, day: 1}
-      }
 
-      it {
-        expect(response.headers["X-Robots-Tag"]).to eq("none")
-      }
+    context "historical" do
+      before { historical_request :search }
+      it { should_include_robots_tag! }
     end
   end
 end

--- a/spec/controllers/sections_controller_spec.rb
+++ b/spec/controllers/sections_controller_spec.rb
@@ -1,25 +1,49 @@
 require 'spec_helper'
 
 describe SectionsController, "GET to #index", vcr: { cassette_name: "sections#index" }  do
-  before(:each) do
-    get :index
+  include CrawlerCommons
+
+  context "non historical" do
+    before { get :index }
+
+    it { should respond_with(:success) }
+    it { should assign_to(:sections) }
+    it { should_not_include_robots_tag! }
   end
 
-  it { should respond_with(:success) }
-  it { should assign_to(:sections) }
+  context "historical request" do
+    before {
+      VCR.use_cassette "sections#historical_index" do
+        historical_request :index
+      end
+    }
+    it { should_include_robots_tag! }
+  end
 end
 
 describe SectionsController, "GET to #show" do
-  context 'with existing section id provided', vcr: { cassette_name: "sections#show" } do
-    let!(:section)    { build :section }
+  include CrawlerCommons
 
-    before(:each) do
-      get :show, id: section.position
+  context 'with existing section id provided', vcr: { cassette_name: "sections#show" } do
+    let!(:section) { build :section }
+
+    context "non historical" do
+      before { get :show, id: section.position }
+
+      it { should respond_with(:success) }
+      it { should assign_to(:section) }
+      it { should assign_to(:chapters) }
+      it { should_not_include_robots_tag! }
     end
 
-    it { should respond_with(:success) }
-    it { should assign_to(:section) }
-    it { should assign_to(:chapters) }
+    context "historical" do
+      before {
+        VCR.use_cassette "sections#historical_show" do
+          historical_request(:show, id: section.position)
+        end
+      }
+      it { should_include_robots_tag! }
+    end
   end
 
   context 'with non existing section id provided', vcr: { cassette_name: "sections#show_9999" } do

--- a/spec/support/crawler_commons.rb
+++ b/spec/support/crawler_commons.rb
@@ -1,0 +1,14 @@
+module CrawlerCommons
+  def should_not_include_robots_tag!
+    expect(response.headers["X-Robots-Tag"]).to_not be_present
+  end
+
+  def should_include_robots_tag!
+    expect(response.headers["X-Robots-Tag"]).to eq("none")
+  end
+
+  def historical_request(action, options={})
+    def_options = {month: 1, year: 2008, day: 1}
+    get action, def_options.merge(options)
+  end
+end

--- a/spec/vcr/sections_historical_index.yml
+++ b/spec/vcr/sections_historical_index.yml
@@ -1,0 +1,123 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://tariff-api.dev.gov.uk/updates/latest
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 15 Apr 2014 21:48:25 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Status:
+      - 200 OK
+      X-Meta-Request-Version:
+      - 0.2.9
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - ! '"ca7bcc06fa785f3ae724a4fec770e4eb"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 0e1845fa086198b2b3561fff3eab8c13
+      X-Runtime:
+      - '0.406174'
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: US-ASCII
+      string: ! '[{"filename":"2014-02-20_KBT009(14051).txt","update_type":"TariffSynchronizer::ChiefUpdate","state":"A","issue_date":"2014-02-20","updated_at":"2014-02-20T14:21:06+00:00","created_at":"2014-02-20T14:02:03+00:00"},{"filename":"2014-02-19_TGB14034.xml","update_type":"TariffSynchronizer::TaricUpdate","state":"A","issue_date":"2014-02-19","updated_at":"2014-02-20T14:20:56+00:00","created_at":"2014-02-20T14:01:20+00:00"}]'
+    http_version: 
+  recorded_at: Tue, 15 Apr 2014 21:48:25 GMT
+- request:
+    method: get
+    uri: http://tariff-api.dev.gov.uk/sections
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 15 Apr 2014 21:48:26 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Status:
+      - 200 OK
+      X-Meta-Request-Version:
+      - 0.2.9
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - ! '"f40a22e604ef275d7c4fed52f6eed99c"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - f29bbd6083b35b461b599e2b5dc2dc96
+      X-Runtime:
+      - '0.457350'
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: US-ASCII
+      string: ! '[{"id":1,"position":1,"title":"Live animals; animal products","numeral":"I","chapter_from":"01","chapter_to":"05","section_note_id":1},{"id":2,"position":2,"title":"Vegetable
+        products","numeral":"II","chapter_from":"06","chapter_to":"14","section_note_id":6},{"id":3,"position":3,"title":"Animal
+        or vegetable fats and oils and their cleavage products; prepared edible fats;
+        animal or vegetable waxes","numeral":"III","chapter_from":"15","chapter_to":"15","section_note_id":null},{"id":4,"position":4,"title":"Prepared
+        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
+        substitutes","numeral":"IV","chapter_from":"16","chapter_to":"24","section_note_id":null},{"id":5,"position":5,"title":"Mineral
+        products","numeral":"V","chapter_from":"25","chapter_to":"27","section_note_id":null},{"id":6,"position":6,"title":"Products
+        of the chemical or allied industries","numeral":"VI","chapter_from":"28","chapter_to":"38","section_note_id":7},{"id":7,"position":7,"title":"Plastics
+        and articles thereof; rubber and articles thereof","numeral":"VII","chapter_from":"39","chapter_to":"40","section_note_id":8},{"id":8,"position":8,"title":"Raw
+        hides and skins, leather, furskins and articles thereof; saddlery and harness;
+        travel goods, handbags and similar containers; articles of animal gut (other
+        than silkworm gut)","numeral":"VIII","chapter_from":"41","chapter_to":"43","section_note_id":null},{"id":9,"position":9,"title":"Wood
+        and articles of wood; wood charcoal; cork and articles of cork; manufactures
+        of straw, of esparto or of other plaiting materials; basket-ware and wickerwork","numeral":"IX","chapter_from":"44","chapter_to":"46","section_note_id":null},{"id":10,"position":10,"title":"Pulp
+        of wood or of other fibrous cellulosic material; recovered (waste and scrap)
+        paper or paperboard; paper and paperboard and articles thereof","numeral":"X","chapter_from":"47","chapter_to":"49","section_note_id":null},{"id":11,"position":11,"title":"Textiles
+        and textile articles","numeral":"XI","chapter_from":"50","chapter_to":"63","section_note_id":2},{"id":12,"position":12,"title":"Footwear,
+        headgear, umbrellas, sun umbrellas, walking-sticks, seat-sticks, whips, riding-crops
+        and parts thereof; prepared feathers and articles made therewith; artificial
+        flowers; articles of human hair","numeral":"XII","chapter_from":"64","chapter_to":"67","section_note_id":null},{"id":13,"position":13,"title":"Articles
+        of stone, plaster, cement, asbestos, mica or similar materials; ceramic products;
+        glass and glassware","numeral":"XIII","chapter_from":"68","chapter_to":"70","section_note_id":null},{"id":14,"position":14,"title":"Natural
+        or cultured pearls, precious or semi-precious stones, precious metals, metals
+        clad with precious metal and articles thereof; imitation jewellery; coins","numeral":"XIV","chapter_from":"71","chapter_to":"71","section_note_id":null},{"id":15,"position":15,"title":"Base
+        metals and articles of base metal","numeral":"XV","chapter_from":"72","chapter_to":"83","section_note_id":3},{"id":16,"position":16,"title":"Machinery
+        and mechanical appliances; electrical equipment; parts thereof, sound recorders
+        and reproducers, television image and sound recorders and reproducers, and
+        parts and accessories of such articles","numeral":"XVI","chapter_from":"84","chapter_to":"85","section_note_id":4},{"id":17,"position":17,"title":"Vehicles,
+        aircraft, vessels and associated transport equipment","numeral":"XVII","chapter_from":"86","chapter_to":"89","section_note_id":5},{"id":18,"position":18,"title":"Optical,
+        photographic, cinematographic, measuring, checking, precision, medical or
+        surgical instruments and apparatus; clocks and watches; musical instruments;
+        parts and accessories thereof","numeral":"XVIII","chapter_from":"90","chapter_to":"92","section_note_id":null},{"id":19,"position":19,"title":"Arms
+        and ammunition; parts and accessories thereof","numeral":"XIX","chapter_from":"93","chapter_to":"93","section_note_id":null},{"id":20,"position":20,"title":"Miscellaneous
+        manufactured articles","numeral":"XX","chapter_from":"94","chapter_to":"96","section_note_id":null},{"id":21,"position":21,"title":"Works
+        of art, collectors'' pieces and antiques","numeral":"XXI","chapter_from":"97","chapter_to":"98","section_note_id":null}]'
+    http_version: 
+  recorded_at: Tue, 15 Apr 2014 21:48:26 GMT
+recorded_with: VCR 2.5.0

--- a/spec/vcr/sections_historical_show.yml
+++ b/spec/vcr/sections_historical_show.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://tariff-api.dev.gov.uk/sections/1?as_of=2014-04-15
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 15 Apr 2014 22:04:09 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Status:
+      - 200 OK
+      X-Meta-Request-Version:
+      - 0.2.9
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - ! '"73526b498664ae52813ebc497cec0622"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 2dd17f754c6676b42a5f4069fd78a6fe
+      X-Runtime:
+      - '0.491261'
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: US-ASCII
+      string: ! '{"id":1,"position":1,"title":"Live animals; animal products","numeral":"I","chapter_from":"01","chapter_to":"05","section_note":"1.
+        Any reference in this section to a particular genus or species of an animal,
+        except where the context otherwise requires, includes a reference to the young
+        of that genus or species.\n2. Except where the context otherwise requires,
+        throughout the nomenclature any reference to `dried'' products also covers
+        products which have been dehydrated, evaporated or freeze-dried.","_response_info":{"links":[{"rel":"self","href":"/trade-tariff/sections/1?as_of=2014-04-15"},{"rel":"sections","href":"/trade-tariff/sections"}]},"chapters":[{"description":"LIVE
+        ANIMALS","goods_nomenclature_item_id":"0100000000","goods_nomenclature_sid":27623,"headings_from":"0101","headings_to":"0106","formatted_description":"Live
+        animals","chapter_note_id":331},{"description":"MEAT AND EDIBLE MEAT OFFAL","goods_nomenclature_item_id":"0200000000","goods_nomenclature_sid":27809,"headings_from":"0201","headings_to":"0210","formatted_description":"Meat
+        and edible meat offal","chapter_note_id":332},{"description":"FISH AND CRUSTACEANS,
+        MOLLUSCS AND OTHER AQUATIC INVERTEBRATES","goods_nomenclature_item_id":"0300000000","goods_nomenclature_sid":28373,"headings_from":"0301","headings_to":"0308","formatted_description":"Fish
+        and crustaceans, molluscs and other aquatic invertebrates","chapter_note_id":333},{"description":"DAIRY
+        PRODUCE; BIRDS'' EGGS; NATURAL HONEY; EDIBLE PRODUCTS OF ANIMAL ORIGIN, NOT
+        ELSEWHERE SPECIFIED OR INCLUDED","goods_nomenclature_item_id":"0400000000","goods_nomenclature_sid":29417,"headings_from":"0401","headings_to":"0410","formatted_description":"Dairy
+        produce; birds'' eggs; natural honey; edible products of animal origin, not
+        elsewhere specified or included","chapter_note_id":334},{"description":"PRODUCTS
+        OF ANIMAL ORIGIN, NOT ELSEWHERE SPECIFIED OR INCLUDED","goods_nomenclature_item_id":"0500000000","goods_nomenclature_sid":30015,"headings_from":"0501","headings_to":"0511","formatted_description":"Products
+        of animal origin, not elsewhere specified or included","chapter_note_id":335}]}'
+    http_version: 
+  recorded_at: Tue, 15 Apr 2014 22:04:09 GMT
+recorded_with: VCR 2.5.0


### PR DESCRIPTION
- Add `X-Robots-Tag` header on historical pages
- Added a spec for `SectionsController` related to `X-Robots-Tag`

[pivotal story](https://www.pivotaltracker.com/n/projects/488191/stories/68707106)
