### PR TITLE
Update env configs, plek & slimmer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ gem "hashie"
 gem "govspeak", "1.2.3"
 
 gem "gds-api-adapters", "14.4.0"
-gem "plek", "1.3.1"
-gem "slimmer", "3.25.0"
+gem "plek", "~> 1.8.1"
+gem "slimmer", "~> 4.2.2"
 gem "addressable"
 
 gem "unicorn", "~> 4.6.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
     net-ssh (2.9.1)
     nokogiri (1.5.11)
     null_logger (0.0.1)
-    plek (1.3.1)
+    plek (1.8.1)
     poltergeist (1.5.1)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -215,9 +215,9 @@ GEM
     simplecov-html (0.5.3)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (3.25.0)
+    slimmer (4.2.2)
+      activesupport
       json
-      lrucache (~> 0.1.3)
       nokogiri (~> 1.5.0)
       null_logger
       plek (>= 0.1.8)
@@ -284,7 +284,7 @@ DEPENDENCIES
   jquery-rails (~> 2.1.3)
   logstasher (= 0.4.8)
   multi_json
-  plek (= 1.3.1)
+  plek (~> 1.8.1)
   poltergeist
   pry-rails
   rails (~> 4.1.6)
@@ -293,7 +293,7 @@ DEPENDENCIES
   shoulda-matchers
   simplecov (~> 0.6.4)
   simplecov-rcov (~> 0.2.3)
-  slimmer (= 3.25.0)
+  slimmer (~> 4.2.2)
   therubyracer (= 0.12.0)
   timecop
   uglifier (>= 1.0.3)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,6 +5,7 @@ TradeTariffFrontend::Application.configure do
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
+  config.eager_load = false
 
   # Log error messages when you accidentally call methods on nil.
   config.whiny_nils = true
@@ -19,24 +20,10 @@ TradeTariffFrontend::Application.configure do
   # Print deprecation notices to the Rails logger
   config.active_support.deprecation = :log
 
-  # Only use best-standards-support built into browsers
-  config.action_dispatch.best_standards_support = :builtin
-
-  # Raise exception on mass assignment protection for Active Record models
-  # config.active_record.mass_assignment_sanitizer = :strict
-
-  # Log the query plan for queries taking more than this (works
-  # with SQLite, MySQL, and PostgreSQL)
-  # config.active_record.auto_explain_threshold_in_seconds = 0.5
-
-  # Do not compress assets
-  config.assets.compress = false
-
   # Expands the lines which load the assets
   config.assets.debug = true
+  config.assets.raise_runtime_errors = true
 
   # Host for Trade Tariff API endpoint
   config.api_host = ENV["TARIFF_API_HOST"] || "http://tariff-api.dev.gov.uk"
-
-  config.eager_load = false
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -4,6 +4,12 @@ TradeTariffFrontend::Application.configure do
   # Code is not reloaded between requests
   config.cache_classes = true
 
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
+
   # Full error reports are disabled and caching is turned on
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
@@ -12,7 +18,7 @@ TradeTariffFrontend::Application.configure do
   config.serve_static_assets = false
 
   # Compress JavaScripts and CSS
-  config.assets.compress = true
+  config.assets.js_compressor = :uglifier
 
   # Don't fallback to assets pipeline if a precompiled asset is missed
   config.assets.compile = true
@@ -62,10 +68,7 @@ TradeTariffFrontend::Application.configure do
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
 
-  config.action_controller.asset_host = ENV['GOVUK_ASSET_HOST']
-  # Log the query plan for queries taking more than this (works
-  # with SQLite, MySQL, and PostgreSQL)
-  # config.active_record.auto_explain_threshold_in_seconds = 0.5
+  config.action_controller.asset_host = Plek.new.asset_root
 
   # Host for Trade Tariff API endpoint
   config.api_host = Plek.new.find("tariff-api")
@@ -74,6 +77,4 @@ TradeTariffFrontend::Application.configure do
   config.logstasher.enabled = true
   config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
   config.logstasher.supress_app_log = true
-
-  config.eager_load = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,13 +6,12 @@ TradeTariffFrontend::Application.configure do
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
+  
+  config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance
   config.serve_static_assets = true
   config.static_cache_control = "public, max-age=3600"
-
-  # Log error messages when you accidentally call methods on nil
-  config.whiny_nils = true
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
@@ -29,14 +28,9 @@ TradeTariffFrontend::Application.configure do
   # ActionMailer::Base.deliveries array.
   # config.action_mailer.delivery_method = :test
 
-  # Raise exception on mass assignment protection for Active Record models
-  # config.active_record.mass_assignment_sanitizer = :strict
-
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
 
   # Host for Trade Tariff API endpoint
   config.api_host = "http://tariff-api.dev.gov.uk"
-
-  config.eager_load = false
 end


### PR DESCRIPTION
Removes commented out config options only applicable to Rails 3

In production:
use plek to set asset_host
specify js_compressor or js will not be compressed

Slimmer version which loads assets from production
Plek for asset_root
