### PR TITLE
Add a rake 'default' task

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ Assumes the GDS development environment is setup via puppet.
 
 ## Specs
 
-To run the spec use the following command: 
+To run the spec use the following command:
 
-    RAILS_ENV=test bundle exec rake ci:setup:rspec spec assets:clean assets:precompile
+    RAILS_ENV=test bundle exec rake

--- a/Rakefile
+++ b/Rakefile
@@ -7,3 +7,8 @@ require File.expand_path('../config/application', __FILE__)
 require 'ci/reporter/rake/rspec'
 
 TradeTariffFrontend::Application.load_tasks
+
+task default: [
+  'ci:setup:rspec',
+  'spec'
+]

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -4,6 +4,6 @@ export GOVUK_ASSET_ROOT=http://static.test.gov.uk
 env
 
 bundle install --path "/home/jenkins/bundles/${JOB_NAME}" --deployment
-bundle exec rake RAILS_ENV=test ci:setup:rspec spec assets:clean assets:precompile
+bundle exec rake RAILS_ENV=test default assets:clean assets:precompile
 RESULT=$?
 exit $RESULT


### PR DESCRIPTION
So users can type `bundle exec rake` and just have it work.

Also update README instructions.