### PR TITLE
Ensure old test runs get cleaned up

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,4 +1,8 @@
 #!/bin/bash -x
+
+# Ensure we clean up any lingering build artefacts
+git clean -fdx
+
 export GOVUK_APP_DOMAIN=test.gov.uk
 export GOVUK_ASSET_ROOT=http://static.test.gov.uk
 env


### PR DESCRIPTION
CI builds were failing prior to this because we'd run
`assets:precompile` on an earlier run and it left old files around
before running the tests.

The JS has totally changed as of f6ed14d, so we need to ensure we get
the fresh JS before running specs.

Verified this works by blowing away the workspace and re-running the
tests on CI - they now pass.