### PR TITLE
Allow content-api tags to not include a details

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,9 +15,9 @@ module ApplicationHelper
     crumbs = [ content_tag(:li, link_to( 'Home', '/' )) ]
     if @artefact && @artefact.primary_section
       @artefact.non_primary_sections.each do |section|
-        crumbs << content_tag(:li, link_to( section.title, section.content_with_tag.web_url))
+        crumbs << content_tag(:li, link_to( section["title"], section["content_with_tag"]["web_url"]))
       end
-      primary_link = link_to( @artefact.primary_section.title, @artefact.primary_section.content_with_tag.web_url)
+      primary_link = link_to( @artefact.primary_section["title"], @artefact.primary_section["content_with_tag"]["web_url"])
       crumbs << content_tag(:li, content_tag(:strong, primary_link))
     end
     content_tag(:ol, crumbs.join('').html_safe, role: "breadcrumbs")

--- a/lib/govuk_artefact.rb
+++ b/lib/govuk_artefact.rb
@@ -5,7 +5,7 @@ class GovukArtefact
   end
 
   def primary_section
-    @data["tags"].select { |tag| tag.details.type == 'section' }.first if @data
+    @data["tags"].select { |tag| tag["details"] && tag["details"]["type"] == 'section' }.first if @data
   end
 
   def primary_root_section


### PR DESCRIPTION
A content-api object wasn't containing an details hash.