### PR TITLE
Fix spelling of `artefact`, and actually test it

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -14,7 +14,7 @@ describe ApplicationController, type: :controller do
 
       get :index
 
-      expect(assigns(:aretefact))
+      expect(assigns(:artefact)).to be_present
     end
 
     describe "caching" do


### PR DESCRIPTION
This test wasn't doing anything before this change, as we weren't
validating the assignment of the variable (which wasn't spelled right anyway).