### PR TITLE
Anonymise IP addresses

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -68,6 +68,7 @@
                             m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
     ga('create', 'UA-26179049-7', {'cookieDomain': '.www.gov.uk'});
+    ga('set', 'anonymizeIp', true);
     ga('send', 'pageview');
   </script>
   <%= javascript_include_tag 'application' %>


### PR DESCRIPTION
As per https://github.com/alphagov/static/pull/544, we should be stripping off the last octet of IP addresses before sending them to GA.