### PR TITLE
Use frontend_toolkit analytics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "logstasher", '0.4.8'
 gem "airbrake", "3.1.16"
 
 gem "coffee-rails"
-gem "govuk_frontend_toolkit", "3.1.0"
+gem "govuk_frontend_toolkit", "3.2.1"
 gem "jquery-rails", "~> 2.1.3"
 gem "sass-rails", "~> 4.0.5"
 gem "therubyracer", "0.12.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_frontend_toolkit (3.1.0)
+    govuk_frontend_toolkit (3.2.1)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_template (0.12.0)
@@ -278,7 +278,7 @@ DEPENDENCIES
   forgery
   gds-api-adapters (~> 18.0)
   govspeak (= 1.2.3)
-  govuk_frontend_toolkit (= 3.1.0)
+  govuk_frontend_toolkit (= 3.2.1)
   govuk_template (= 0.12.0)
   hashie
   httparty

--- a/app/assets/javascripts/analytics-init.js
+++ b/app/assets/javascripts/analytics-init.js
@@ -1,0 +1,42 @@
+(function() {
+  "use strict";
+
+  // Load Google Analytics libraries
+  GOVUK.Tracker.load();
+
+  // Use document.domain in dev, preview and staging so that tracking works
+  // Otherwise explicitly set the domain as www.gov.uk (and not gov.uk).
+  var cookieDomain = (document.domain === 'www.gov.uk') ? '.www.gov.uk' : document.domain;
+
+  // Configure profiles and make interface public
+  // for custom dimensions, virtual pageviews and events
+  GOVUK.analytics = new GOVUK.Tracker({
+    universalId: 'UA-26179049-7',
+    classicId: 'UA-26179049-1',
+    cookieDomain: cookieDomain
+  });
+
+  var $section = $('head meta[name="govuk:section"]'),
+      $needIds = $('head meta[name="govuk:need-ids"]');
+
+  // Set custom dimensions before tracking pageviews
+  if ($section) {
+    GOVUK.analytics.setDimension(1, $section.attr('content'), 'Section');
+  }
+
+  if ($needIds) {
+    GOVUK.analytics.setDimension(3, $needIds.attr('content'), 'NeedID');
+  }
+
+  GOVUK.analytics.setDimension(2, 'custom-tool', 'Format');
+  if (window.devicePixelRatio) {
+    GOVUK.analytics.setDimension(11, window.devicePixelRatio, 'Pixel Ratio', 2);
+  }
+
+  // Activate any event plugins eg. print intent, error tracking
+  GOVUK.analyticsPlugins.error();
+  GOVUK.analyticsPlugins.printIntent();
+
+  // Track initial pageview
+  GOVUK.analytics.trackPageview();
+})();

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,6 +2,11 @@
 //= require jquery.tabs
 //= require jquery.datepicker
 //= require jquery.history
+//= require govuk/analytics/google-analytics-universal-tracker
+//= require govuk/analytics/google-analytics-classic-tracker
+//= require govuk/analytics/tracker
+//= require govuk/analytics/print-intent
+//= require govuk/analytics/error-tracking
 //= require popup
 //= require_tree .
 

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -12,6 +12,15 @@
   <meta name="x-section-link" content="/browse/business" />
   <meta name="x-section-format" content="trade-tariff" />
 
+  <% if @artefact %>
+    <% if @artefact.primary_root_section %>
+      <meta name="govuk:section" content="<%= @artefact.primary_root_section["title"].downcase %>">
+    <% end %>
+    <% if @artefact.need_ids %>
+      <meta name="govuk:need-ids" content="<%= @artefact.need_ids.join(',') %>">
+    <% end %>
+  <% end %>
+
   <link rel="search" type="application/opensearchdescription+xml" href="<%= opensearch_url(format: :xml) %>" title="Trade Tariff Search" />
 <% end %>
 
@@ -28,48 +37,5 @@
 <% end %>
 
 <% content_for :body_end do %>
-  <script id="ga-params" type="text/javascript">
-    window.GOVUK = window.GOVUK || {};
-
-    GOVUK.Analytics = GOVUK.Analytics || {};
-    var _gaq = _gaq || [];
-    _gaq.push(['_setAccount', 'UA-26179049-1']);
-    if(document.domain=='www.gov.uk') {
-      _gaq.push(['_setDomainName', '.www.gov.uk']);
-    } else {
-      _gaq.push(['_setDomainName', document.domain]);
-    }
-    _gaq.push(['_setAllowLinker', true]);
-      // track pixel density ratio
-    if (window.devicePixelRatio) {
-      _gaq.push(['_setCustomVar', 11, 'Pixel Ratio', String(window.devicePixelRatio), 2 ]);
-    }
-    <% if @artefact && @artefact.primary_root_section %>
-      _gaq.push(["_setCustomVar",1,"Section","<%= @artefact.primary_root_section["title"].downcase %>",3]);
-      GOVUK.Analytics.Section = "<%= @artefact.primary_root_section["title"].downcase %>";
-      _gaq.push(["_setCustomVar",3,"NeedID","<%= @artefact.need_ids.join(',') %>",3]);
-      GOVUK.Analytics.NeedID = "<%= @artefact.need_ids.join(',') %>";
-      _gaq.push(["_setCustomVar",4,"Proposition","<%= @artefact.proposition %>",3]);
-      GOVUK.Analytics.Proposition = "<%= @artefact.proposition %>";
-    <% end %>
-    _gaq.push(["_setCustomVar",2,"Format","custom-tool",3]);
-    GOVUK.Analytics.Format = "custom-tool";
-    _gaq.push(['_gat._anonymizeIp']);
-    _gaq.push(['_trackPageview']);
-    (function() {
-      var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-    })();
-  </script>
-  <script id="ga-ua-params" type="text/javascript">
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-                            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-26179049-7', {'cookieDomain': '.www.gov.uk'});
-    ga('set', 'anonymizeIp', true);
-    ga('send', 'pageview');
-  </script>
   <%= javascript_include_tag 'application' %>
 <% end %>

--- a/lib/govuk_artefact.rb
+++ b/lib/govuk_artefact.rb
@@ -17,11 +17,7 @@ class GovukArtefact
   end
 
   def need_ids
-    @data.details.need_ids
-  end
-
-  def proposition
-    @data.details.business_proposition ? 'business' : 'citizen'
+    @data.details.need_ids if @data && @data.details
   end
 
   def non_primary_sections


### PR DESCRIPTION
As part of the switch over to using Universal analytics we need to track to both Classic and Universal and check that what is tracked is comparable. For this govuk_frontend_toolkit has some [analytics helpers](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md).

* Remove inline analytics code
* Remove proposition custom variable
* Use frontend_toolkit to track pageviews, events and custom dimensions to both classic and universal
* Move section and need ids into meta tags for analytics JS to read (matching slimmer's approach)
* Introduce print intent and js error events