### PR TITLE
Remove the Brakeman gem to fix master builds on Jenkins CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ gem "responders", "~> 2.0"
 group :development, :test do
   gem "pry-rails"
   gem "bundler-audit"
-  gem "brakeman", "~> 3.0.2", require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,16 +42,6 @@ GEM
       builder
       multi_json
     arel (6.0.0)
-    brakeman (3.0.2)
-      erubis (~> 2.6)
-      fastercsv (~> 1.5)
-      haml (>= 3.0, < 5.0)
-      highline (~> 1.6.20)
-      multi_json (~> 1.2)
-      ruby2ruby (~> 2.1.1)
-      ruby_parser (~> 3.6.2)
-      sass (~> 3.0)
-      terminal-table (~> 1.4)
     builder (3.2.2)
     bundler-audit (0.3.1)
       bundler (~> 1.2)
@@ -94,7 +84,6 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
-    fastercsv (1.5.5)
     forgery (0.6.0)
     gds-api-adapters (18.3.1)
       link_header
@@ -115,10 +104,7 @@ GEM
       sass (>= 3.2.0)
     govuk_template (0.12.0)
       rails (>= 3.1)
-    haml (4.0.6)
-      tilt
     hashie (3.3.1)
-    highline (1.6.21)
     hike (1.2.3)
     htmlentities (4.3.3)
     http-cookie (1.0.2)
@@ -230,11 +216,6 @@ GEM
       rspec-mocks (~> 3.2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
-    ruby2ruby (2.1.3)
-      ruby_parser (~> 3.1)
-      sexp_processor (~> 4.0)
-    ruby_parser (3.6.4)
-      sexp_processor (~> 4.1)
     safe_yaml (1.0.4)
     sanitize (2.1.0)
       nokogiri (>= 1.4.4)
@@ -245,7 +226,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (~> 1.1)
-    sexp_processor (4.5.0)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
     simplecov (0.9.2)
@@ -269,7 +249,6 @@ GEM
       colorize (>= 0.7.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    terminal-table (1.4.5)
     therubyracer (0.12.1)
       libv8 (~> 3.16.14.0)
       ref
@@ -306,7 +285,6 @@ PLATFORMS
 DEPENDENCIES
   addressable
   airbrake (~> 4.1)
-  brakeman (~> 3.0.2)
   bundler-audit
   capistrano (~> 3.4)
   capybara (~> 2.4)


### PR DESCRIPTION
- The builds on Jenkins CI
  (https://ci-new.alphagov.co.uk/job/govuk_trade_tariff_frontend/)
  have been failing since April 16th, when the version of Ruby that
  this app uses was updated to 2.2.2. Brakeman is unsupported for Ruby
  versions greater than 1.9.3.
- Jenkins was just running master builds for us - branch builds run
  via Travis. I assume this is the case because people committing to
  trade-tariff with any regularity don't work here anymore and
  therefore can't see our Jenkins CI? Given that, it seemed OK to
  remove Brakeman from the Gemfile because no-one has been looking at
  Jenkins' master builds, or, therefore, Brakeman, and it's better
  that builds pass than not.