### PR TITLE
Switch off classic analytics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "logstasher", "~> 0.6"
 gem "airbrake", "~> 4.1"
 
 gem "coffee-rails", "~> 4.1"
-gem "govuk_frontend_toolkit", "~> 3.2"
+gem "govuk_frontend_toolkit", "~> 3.5.1"
 gem "jquery-rails", "~> 2.1.3"
 gem "sass-rails", "~> 5.0"
 gem "therubyracer", "~> 0.12.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
       kramdown (~> 1.4.1)
       nokogiri (~> 1.5)
       sanitize (~> 2.1.0)
-    govuk_frontend_toolkit (3.2.1)
+    govuk_frontend_toolkit (3.5.1)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_template (0.12.0)
@@ -294,7 +294,7 @@ DEPENDENCIES
   forgery
   gds-api-adapters (~> 18.3)
   govspeak (~> 3.3)
-  govuk_frontend_toolkit (~> 3.2)
+  govuk_frontend_toolkit (~> 3.5.1)
   govuk_template (= 0.12.0)
   hashie
   httparty

--- a/app/assets/javascripts/analytics-init.js
+++ b/app/assets/javascripts/analytics-init.js
@@ -11,8 +11,7 @@
   // Configure profiles and make interface public
   // for custom dimensions, virtual pageviews and events
   GOVUK.analytics = new GOVUK.Tracker({
-    universalId: 'UA-26179049-7',
-    classicId: 'UA-26179049-1',
+    universalId: 'UA-26179049-1',
     cookieDomain: cookieDomain
   });
 


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/story/show/93551518

We're moving over to universal analytics a few apps at a time. This is
the first app to go over. We're keeping the classic tracking code but
sending it to universal analytics instead.
This work should only be merged after this
https://github.com/alphagov/govuk_frontend_toolkit/pull/190 has been
merged, and the front end toolkit has been updated.

I'd like @fofr to check this work as he is the person that spec'ed
the ticket.