### PR TITLE
Remove Need IDs custom dimension

### DIFF
--- a/app/assets/javascripts/analytics-init.js
+++ b/app/assets/javascripts/analytics-init.js
@@ -15,16 +15,11 @@
     cookieDomain: cookieDomain
   });
 
-  var $section = $('head meta[name="govuk:section"]'),
-      $needIds = $('head meta[name="govuk:need-ids"]');
+  var $section = $('head meta[name="govuk:section"]');
 
   // Set custom dimensions before tracking pageviews
   if ($section) {
     GOVUK.analytics.setDimension(1, $section.attr('content'), 'Section');
-  }
-
-  if ($needIds) {
-    GOVUK.analytics.setDimension(3, $needIds.attr('content'), 'NeedID');
   }
 
   GOVUK.analytics.setDimension(2, 'custom-tool', 'Format');

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -16,9 +16,6 @@
     <% if @artefact.primary_root_section %>
       <meta name="govuk:section" content="<%= @artefact.primary_root_section["title"].downcase %>">
     <% end %>
-    <% if @artefact.need_ids %>
-      <meta name="govuk:need-ids" content="<%= @artefact.need_ids.join(',') %>">
-    <% end %>
   <% end %>
 
   <link rel="search" type="application/opensearchdescription+xml" href="<%= opensearch_url(format: :xml) %>" title="Trade Tariff Search" />

--- a/lib/govuk_artefact.rb
+++ b/lib/govuk_artefact.rb
@@ -16,10 +16,6 @@ class GovukArtefact
     primary_root_section
   end
 
-  def need_ids
-    @data.details.need_ids if @data && @data.details
-  end
-
   def non_primary_sections
     if (section = primary_section)
       sections = recurse_sections(section)


### PR DESCRIPTION
This dimension isn’t being used by anyone and will not be configured in the Universal Analytics profile.