### PR TITLE
Fully remove Google Analytics classic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "logstasher", "~> 0.6"
 gem "airbrake", "~> 4.1"
 
 gem "coffee-rails", "~> 4.1"
-gem "govuk_frontend_toolkit", "~> 3.5.1"
+gem "govuk_frontend_toolkit", "~> 4.0.0"
 gem "jquery-rails", "~> 2.1.3"
 gem "sass-rails", "~> 5.0"
 gem "therubyracer", "~> 0.12.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
       kramdown (~> 1.4.1)
       nokogiri (~> 1.5)
       sanitize (~> 2.1.0)
-    govuk_frontend_toolkit (3.5.1)
+    govuk_frontend_toolkit (4.0.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_template (0.12.0)
@@ -294,7 +294,7 @@ DEPENDENCIES
   forgery
   gds-api-adapters (~> 18.3)
   govspeak (~> 3.3)
-  govuk_frontend_toolkit (~> 3.5.1)
+  govuk_frontend_toolkit (~> 4.0.0)
   govuk_template (= 0.12.0)
   hashie
   httparty

--- a/app/assets/javascripts/analytics-init.js
+++ b/app/assets/javascripts/analytics-init.js
@@ -2,7 +2,7 @@
   "use strict";
 
   // Load Google Analytics libraries
-  GOVUK.Tracker.load();
+  GOVUK.Analytics.load();
 
   // Use document.domain in dev, preview and staging so that tracking works
   // Otherwise explicitly set the domain as www.gov.uk (and not gov.uk).
@@ -10,7 +10,7 @@
 
   // Configure profiles and make interface public
   // for custom dimensions, virtual pageviews and events
-  GOVUK.analytics = new GOVUK.Tracker({
+  GOVUK.analytics = new GOVUK.Analytics({
     universalId: 'UA-26179049-1',
     cookieDomain: cookieDomain
   });
@@ -19,12 +19,12 @@
 
   // Set custom dimensions before tracking pageviews
   if ($section) {
-    GOVUK.analytics.setDimension(1, $section.attr('content'), 'Section');
+    GOVUK.analytics.setDimension(1, $section.attr('content'));
   }
 
-  GOVUK.analytics.setDimension(2, 'custom-tool', 'Format');
+  GOVUK.analytics.setDimension(2, 'custom-tool'); // Format
   if (window.devicePixelRatio) {
-    GOVUK.analytics.setDimension(11, window.devicePixelRatio, 'Pixel Ratio', 2);
+    GOVUK.analytics.setDimension(11, window.devicePixelRatio);
   }
 
   // Activate any event plugins eg. print intent, error tracking

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,8 +3,7 @@
 //= require jquery.datepicker
 //= require jquery.history
 //= require govuk/analytics/google-analytics-universal-tracker
-//= require govuk/analytics/google-analytics-classic-tracker
-//= require govuk/analytics/tracker
+//= require govuk/analytics/analytics
 //= require govuk/analytics/print-intent
 //= require govuk/analytics/error-tracking
 //= require popup


### PR DESCRIPTION
Following on from https://github.com/alphagov/govuk_frontend_toolkit/pull/194 and https://github.com/alphagov/trade-tariff-frontend/pull/180

* Bump govuk_frontend_toolkit to pull in latest analytics
* Remove references to classic tracker
* Remove classic specific arguments (eg custom variable name and scope)
* Update references of `GOVUK.Tracker` to `GOVUK.Analytics`