### PR TITLE
Bump GDS API adapters to 20.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "httparty"
 gem "hashie"
 gem "govspeak", "~> 3.3"
 
-gem "gds-api-adapters", "~> 18.3"
+gem "gds-api-adapters", "20.1.1"
 gem "govuk_template", "0.12.0"
 gem "plek", "~> 1.8.1"
 gem "addressable"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
     forgery (0.6.0)
-    gds-api-adapters (18.3.1)
+    gds-api-adapters (20.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -156,7 +156,7 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.3)
       pry (>= 0.9.10)
-    rack (1.6.2)
+    rack (1.6.4)
     rack-cache (1.2)
       rack (>= 0.4)
     rack-test (0.6.3)
@@ -260,7 +260,7 @@ GEM
       json (>= 1.8.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.6)
+    unf_ext (0.0.7.1)
     unicorn (4.6.3)
       kgio (~> 2.6)
       rack
@@ -289,7 +289,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1)
   factory_girl_rails
   forgery
-  gds-api-adapters (~> 18.3)
+  gds-api-adapters (= 20.1.1)
   govspeak (~> 3.3)
   govuk_frontend_toolkit (~> 4.0.0)
   govuk_template (= 0.12.0)


### PR DESCRIPTION
This changes the user agent to include the app
name in API requests.

https://trello.com/c/qkHdtob4/247-bump-gds-api-adapters-everywhere-it-s-used-to-include-user-agent-information