### PR TITLE
proxy complete request URI down to api

### DIFF
--- a/lib/trade_tariff_frontend/request_forwarder.rb
+++ b/lib/trade_tariff_frontend/request_forwarder.rb
@@ -49,7 +49,11 @@ module TradeTariffFrontend
     private
 
     def request_url_for(rackreq)
-      "http://#{host}:#{port}#{api_request_path_for(rackreq.env["PATH_INFO"])}"
+      "http://#{host}:#{port}#{request_uri_for(rackreq)}"
+    end
+
+    def request_uri_for(rackreq)
+      api_request_path_for(rackreq.env["PATH_INFO"] + "?" + rackreq.env["QUERY_STRING"])
     end
 
     def request_headers_for(env)

--- a/spec/middleware/trade_tariff_frontend/request_forwarder_spec.rb
+++ b/spec/middleware/trade_tariff_frontend/request_forwarder_spec.rb
@@ -1,9 +1,10 @@
 require 'spec_helper'
 
 describe TradeTariffFrontend::RequestForwarder do
-  let(:app)          { ->(env) { [200, env, "app"] } }
-  let(:host)         { 'http://tariff-api.example.com' }
-  let(:request_path) { '/sections/1' }
+  let(:app)            { ->(env) { [200, env, "app"] } }
+  let(:host)           { "http://tariff-api.example.com" }
+  let(:request_path)   { "/sections/1" }
+  let(:request_params) { "?page=2"}
 
   let(:response_body) { "example" }
 
@@ -90,6 +91,20 @@ describe TradeTariffFrontend::RequestForwarder do
 
     expect(status).to eq 405 # METHOD NOT ALLOWED
     expect(body).to be_blank
+  end
+
+  it "forwards request params" do
+    request_uri = request_path + request_params
+
+    stub_request(:get, "#{host}#{request_uri}").to_return(
+      status: 200,
+      body: response_body,
+      headers: { "Content-Length" => response_body.size }
+    )
+
+    status, env, body = middleware.call env_for(request_uri)
+
+    expect(status).to eq(200)
   end
 
   def env_for(url, opts = {})


### PR DESCRIPTION
so that parameters like `page` get correctly proxied to api