### PR TITLE
Register special routes.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "httparty", "~> 0.13"
 gem "hashie", "~> 3.4"
 gem "govspeak", "~> 3.4"
 
-gem "gds-api-adapters", "20.1.1"
+gem "gds-api-adapters", "23.2.2"
 gem "govuk_template", "~> 0.14"
 gem "plek", "~> 1.11"
 gem "addressable", "~> 2.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
     forgery (0.6.0)
-    gds-api-adapters (20.1.1)
+    gds-api-adapters (23.2.2)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -289,7 +289,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1)
   factory_girl_rails
   forgery
-  gds-api-adapters (= 20.1.1)
+  gds-api-adapters (= 23.2.2)
   govspeak (~> 3.4)
   govuk_frontend_toolkit (~> 4.1)
   govuk_template (~> 0.14)
@@ -316,3 +316,6 @@ DEPENDENCIES
   vcr
   webmock (~> 1.21)
   yajl-ruby (~> 1.2)
+
+BUNDLED WITH
+   1.10.5

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,0 +1,23 @@
+namespace :publishing_api do
+  desc "Publish special routes such as the homepage"
+  task :publish_special_routes => :environment do
+    require 'gds_api/publishing_api/special_route_publisher'
+
+    publisher = GdsApi::PublishingApi::SpecialRoutePublisher.new(logger: Logger.new(STDOUT))
+
+    publisher.publish(
+      content_id: "81e8949b-a3fa-4712-97ff-decdd80024c8",
+      base_path: "/trade-tariff",
+      type: "prefix",
+      rendering_app: "tariff",
+      publishing_app: "tariff",
+      title: "Trade tariff finder",
+      description: "Landing page for the trade tariff finder.",
+      public_updated_at: Time.zone.now.iso8601,
+      update_type: "major",
+    )
+  end
+end
+
+desc "Temporary alias of publishing_api:publish_special_routes for backward compatibility"
+task "router:register" => "publishing_api:publish_special_routes"


### PR DESCRIPTION
https://trello.com/c/blLdEZN5/292-make-apps-register-special-routes-on-deploy

We've introduced a new special_route format[1] to allow us to register
unusual routes which don't have a real format associated with them. This
supersedes the previous approach of registering such routes via the
router. The advantage of registering with publishing api is that the
routes will also be reserved with url-arbiter which should eliminate the
risk of clashes.

This adds a rake task to register these routes via that
mechanism, and removes the old method of registering directly with the
router.

The intention is to run this rake task on deploy (as we do for the route
registration at present).

[1] alphagov/govuk-content-schemas#106