### PR TITLE
Fix broken background image

### DIFF
--- a/app/assets/stylesheets/tariff.scss
+++ b/app/assets/stylesheets/tariff.scss
@@ -1030,7 +1030,7 @@ ul.commodities {
     margin: 0;
     padding: 0;
     position:relative;
-    background-image: url(commodity-indents.png);
+    background-image: image-url("commodity-indents.png");
     background-repeat: no-repeat;
     background-color: transparent;
     @include contain-float;


### PR DESCRIPTION
This was getting linked directly, rather than with the digest hash, as for other assets.  Eg,

- `image-url("expand-collapse-transparent.png")` => https://assets.digital.cabinet-office.gov.uk/tariff/expand-collapse-transparent-8e508b555567c0618975a4a2db35d2571b3772a6e69303f97a4bc4866e365e8c.png
- `url("commodity-indents.png")` => https://assets.digital.cabinet-office.gov.uk/tariff/commodity-indents.png