### PR TITLE
Upgrade govuk_template gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
     govuk_frontend_toolkit (4.1.1)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_template (0.16.1)
+    govuk_template (0.16.2)
       rails (>= 3.1)
     hashie (3.4.2)
     htmlentities (4.3.4)

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -25,28 +25,3 @@ Rails.application.config.assets.precompile += %w{
   tariff.css
   tariff-print.css
 }
-
-# Assets from govuk-template
-# See issue https://github.com/alphagov/govuk_template/issues/87
-Rails.application.config.assets.precompile += %w(
-  apple-touch-icon-152x152.png
-  apple-touch-icon-120x120.png
-  apple-touch-icon-76x76.png
-  apple-touch-icon-60x60.png
-  opengraph-image.png
-  open-government-licence.png
-  open-government-licence_2x.png
-  govuk-crest.png
-  govuk-crest-2x.png
-  govuk-crest-ie.png
-  gov.uk_logotype_crown.png
-  gov.uk_logotype_crown-1x.png
-  gov.uk_logotype_crown_invert_trans.png
-  file.png
-)
-
-
-
-
-
-


### PR DESCRIPTION
Precompiled files have been added to `govuk_template` here:
https://github.com/alphagov/govuk_template/pull/191/files

So removing them after they have been added in this PR: 
https://github.com/alphagov/trade-tariff-frontend/pull/202/files
