### PR TITLE
Remove hard-coded text that is no longer needed

### DIFF
--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -17,11 +17,6 @@
   <li><%= link_to "UK Trade Tariff: Volume 3", "https://www.gov.uk/government/collections/uk-trade-tariff-volume-3"%></li>
 </ul>
 
-<p>
-  European Union import, export and storage procedures are changing from 1 May 2016. Read guidance on the <a href="https://www.gov.uk/guidance/introduction-of-the-union-customs-code-ucc">Union Customs Code</a>
-  and <a href="https://www.gov.uk/government/publications/customs-information-paper-39-2015-implementation-of-the-union-customs-code">how it will be introduced</a> to find out if you'll be affected.
-</p>
-
 <h2>Terms and conditions</h2>
 <p>
   Trade Tariff users should be aware that in any case where information in the


### PR DESCRIPTION
- Text removed from https://www.gov.uk/trade-tariff
- This is for [Trello card]( https://trello.com/c/kYqywopn/412-remove-text-from-trade-tariff-page)