### PR TITLE
Remove gds-api-adapters & test helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem "httparty", "~> 0.13"
 gem "hashie", "~> 3.4"
 gem "govspeak", "~> 3.4"
 
-gem "gds-api-adapters", "23.2.2"
 gem "govuk_template", "~> 0.17"
 gem "plek", "~> 1.11"
 gem "addressable", "~> 2.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    PriorityQueue (0.1.2)
     actionmailer (4.2.7.1)
       actionpack (= 4.2.7.1)
       actionview (= 4.2.7.1)
@@ -62,8 +61,6 @@ GEM
     dalli (2.7.6)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.24)
-      unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
     factory_girl (4.5.0)
@@ -74,13 +71,6 @@ GEM
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     forgery (0.6.0)
-    gds-api-adapters (23.2.2)
-      link_header
-      lrucache (~> 0.1.1)
-      null_logger
-      plek
-      rack-cache
-      rest-client (~> 1.8.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     govspeak (3.4.0)
@@ -95,8 +85,6 @@ GEM
       rails (>= 3.1)
     hashie (3.4.2)
     htmlentities (4.3.4)
-    http-cookie (1.0.2)
-      domain_name (~> 0.5)
     httparty (0.13.5)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
@@ -107,7 +95,6 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.3)
     kramdown (1.5.0)
-    link_header (0.0.8)
     lograge (0.3.6)
       actionpack (>= 3)
       activesupport (>= 3)
@@ -115,8 +102,6 @@ GEM
     logstash-event (1.2.02)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
-    lrucache (0.1.4)
-      PriorityQueue (~> 0.1.2)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
     mime-types (2.99.2)
@@ -125,12 +110,10 @@ GEM
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    netrc (0.10.3)
     newrelic_rpm (3.16.0.318)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
-    null_logger (0.0.1)
     pkg-config (1.1.7)
     plek (1.11.0)
     poltergeist (1.6.0)
@@ -142,8 +125,6 @@ GEM
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.4)
-    rack-cache (1.2)
-      rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
     rack-timeout (0.4.2)
@@ -179,10 +160,6 @@ GEM
     rake (11.2.2)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
     rspec-core (3.2.3)
       rspec-support (~> 3.2.0)
     rspec-expectations (3.2.1)
@@ -240,9 +217,6 @@ GEM
     uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.1)
     vcr (2.9.3)
     webmock (1.21.0)
       addressable (>= 2.3.6)
@@ -266,7 +240,6 @@ DEPENDENCIES
   dalli (~> 2.7)
   factory_girl_rails
   forgery
-  gds-api-adapters (= 23.2.2)
   govspeak (~> 3.4)
   govuk_frontend_toolkit (~> 4.10)
   govuk_template (~> 0.17)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,7 @@
 require "api_entity"
-require "gds_api/helpers"
 
 class ApplicationController < ActionController::Base
   protect_from_forgery
-  include GdsApi::Helpers
   include TradeTariffFrontend::ViewContext::Controller
 
   before_filter :set_last_updated

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,6 @@ SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
 require File.expand_path("../../config/environment", __FILE__)
 
 require 'rspec/rails'
-require 'gds_api/test_helpers/content_api'
 
 Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 
@@ -38,7 +37,6 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
 
   config.include FactoryGirl::Syntax::Methods
-  config.include GdsApi::TestHelpers::ContentApi
   config.include Rails.application.routes.url_helpers
   config.include Capybara::DSL
 

--- a/spec/support/gds_api.rb
+++ b/spec/support/gds_api.rb
@@ -1,5 +1,0 @@
-require 'gds_api/test_helpers/content_api'
-
-RSpec.configure do |config|
-  config.include GdsApi::TestHelpers::ContentApi, :type => :controller
-end


### PR DESCRIPTION
I am currently looking into usage of the content-api, since we are planning on deprecating that.

Since https://github.com/bitzesty/trade-tariff-frontend/pull/13 this app no longer depends on the content-api. This commit removes the last references to gds-api-adapters and test helpers.